### PR TITLE
諸々のリファクタリング

### DIFF
--- a/crates/domain/src/entity/record.rs
+++ b/crates/domain/src/entity/record.rs
@@ -1,4 +1,4 @@
-use chrono::NaiveDateTime;
+use chrono::{DateTime, Utc};
 use getset::{Getters, Setters};
 
 use super::clear_type::ClearType;
@@ -18,7 +18,7 @@ pub struct Record {
     #[getset(get = "pub", set = "pub")]
     play_count: u32,
     #[getset(get = "pub", set = "pub")]
-    updated_at: NaiveDateTime,
+    updated_at: DateTime<Utc>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -30,7 +30,7 @@ impl Record {
         score: u32,
         clear_type: ClearType,
         play_count: u32,
-        updated_at: NaiveDateTime,
+        updated_at: DateTime<Utc>,
     ) -> Self {
         Self {
             id,
@@ -48,7 +48,7 @@ impl Record {
         sheet_id: String,
         score: u32,
         clear_type: ClearType,
-        updated_at: NaiveDateTime,
+        updated_at: DateTime<Utc>,
     ) -> Self {
         Self::new(
             String::new(),
@@ -65,7 +65,7 @@ impl Record {
         &mut self,
         score: u32,
         clear_type: ClearType,
-        updated_at: NaiveDateTime,
+        updated_at: DateTime<Utc>,
     ) {
         self.set_play_count(self.play_count() + 1);
         if score > *self.score() {

--- a/crates/domain/src/entity/user.rs
+++ b/crates/domain/src/entity/user.rs
@@ -1,4 +1,4 @@
-use chrono::NaiveDateTime;
+use chrono::{DateTime, Utc};
 use getset::{Getters, Setters};
 
 use super::rating::Rating;
@@ -20,7 +20,7 @@ pub struct User {
     #[getset(get = "pub")]
     is_admin: bool,
     #[getset(get = "pub")]
-    created_at: NaiveDateTime,
+    created_at: DateTime<Utc>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -33,7 +33,7 @@ impl User {
         xp: u32,
         credits: u32,
         is_admin: bool,
-        created_at: NaiveDateTime,
+        created_at: DateTime<Utc>,
     ) -> Self {
         Self {
             id,
@@ -56,7 +56,7 @@ impl User {
             xp: 0,
             credits: 0,
             is_admin: false,
-            created_at: chrono::Utc::now().naive_utc(),
+            created_at: chrono::Utc::now(),
         }
     }
 
@@ -95,7 +95,8 @@ mod tests {
         let timestamp = chrono::NaiveDate::from_ymd_opt(2025, 10, 21)
             .unwrap()
             .and_hms_opt(8, 30, 0)
-            .unwrap();
+            .unwrap()
+            .and_utc();
 
         let user = User::new(
             "user-id".to_owned(),

--- a/crates/domain/src/repository/record.rs
+++ b/crates/domain/src/repository/record.rs
@@ -47,6 +47,15 @@ pub trait RecordRepository: Send + Sync {
         user_id: &str,
     ) -> impl Future<Output = Result<Vec<RecordWithMetadata>, RecordRepositoryError>> + Send;
 
+    /// Loads records for the specified user and sheet IDs. More efficient than loading all records
+    /// when only a subset is needed. Returns an empty vector if none of the specified sheet IDs
+    /// have records.
+    fn find_by_user_id_and_sheet_ids(
+        &self,
+        user_id: &str,
+        sheet_ids: &[String],
+    ) -> impl Future<Output = Result<Vec<Record>, RecordRepositoryError>> + Send;
+
     /// Persists a new record aggregate. Callers must guarantee that the record identifier is
     /// unique; the repository will generate an error if the tuple `(user_id, sheet_id)` already
     /// exists.

--- a/crates/domain/src/service/rating.rs
+++ b/crates/domain/src/service/rating.rs
@@ -7,7 +7,7 @@ pub fn calculate_user_rating(records: &[RecordWithMetadata]) -> Rating {
     let mut values: Vec<u32> = records
         .iter()
         .filter(|entry| !entry.is_test)
-        .map(|entry| calculate_single_track_rating(&entry.level, *entry.record.score()))
+        .map(|entry| calculate_sheet_rating(&entry.level, *entry.record.score()))
         .collect();
 
     if values.is_empty() {
@@ -20,7 +20,7 @@ pub fn calculate_user_rating(records: &[RecordWithMetadata]) -> Rating {
     Rating::new(total / count as u32)
 }
 
-fn calculate_single_track_rating(level: &Level, score: u32) -> u32 {
+fn calculate_sheet_rating(level: &Level, score: u32) -> u32 {
     let (integer, decimal) = level.components();
     let base = integer * 100 + decimal * 10;
     let bonus = compute_score_bonus(score);

--- a/crates/domain/src/testing/datetime.rs
+++ b/crates/domain/src/testing/datetime.rs
@@ -1,17 +1,17 @@
-use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
+use chrono::{DateTime, Utc};
 
 /// Returns a reproducible timestamp for fixtures. Implicitly depends on `chrono` being available in
 /// the consuming crate.
-pub fn sample_timestamp() -> NaiveDateTime {
+pub fn sample_timestamp() -> DateTime<Utc> {
     timestamp(2025, 10, 21, 12, 0, 0)
 }
 
 /// Returns a timestamp slightly ahead of [`sample_timestamp`] for scenarios needing variation.
-pub fn later_timestamp() -> NaiveDateTime {
+pub fn later_timestamp() -> DateTime<Utc> {
     timestamp(2025, 10, 21, 12, 30, 0)
 }
 
-/// Constructs a `NaiveDateTime` from the provided components, panicking if they form an invalid
+/// Constructs a `DateTime<Utc>` from the provided components, panicking if they form an invalid
 /// combination.
 pub fn timestamp(
     year: i32,
@@ -20,8 +20,10 @@ pub fn timestamp(
     hour: u32,
     minute: u32,
     second: u32,
-) -> NaiveDateTime {
-    let date = NaiveDate::from_ymd_opt(year, month, day).expect("invalid date for fixture");
-    let time = NaiveTime::from_hms_opt(hour, minute, second).expect("invalid time for fixture");
-    NaiveDateTime::new(date, time)
+) -> DateTime<Utc> {
+    chrono::NaiveDate::from_ymd_opt(year, month, day)
+        .expect("invalid date for fixture")
+        .and_hms_opt(hour, minute, second)
+        .expect("invalid time for fixture")
+        .and_utc()
 }

--- a/crates/domain/src/testing/user.rs
+++ b/crates/domain/src/testing/user.rs
@@ -1,4 +1,4 @@
-use chrono::NaiveDateTime;
+use chrono::{DateTime, Utc};
 
 use crate::entity::{rating::Rating, user::User};
 
@@ -15,7 +15,7 @@ pub struct UserSample {
 
 impl UserSample {
     /// Builds a `User` aggregate based on this sample and the supplied metadata.
-    pub fn build(&self, created_at: NaiveDateTime, is_admin: bool) -> User {
+    pub fn build(&self, created_at: DateTime<Utc>, is_admin: bool) -> User {
         User::new(
             self.id.to_owned(),
             self.card.to_owned(),
@@ -56,10 +56,10 @@ pub const USER3: UserSample = UserSample {
     credits: 456,
 };
 
-pub fn created_at1() -> NaiveDateTime {
+pub fn created_at1() -> DateTime<Utc> {
     sample_timestamp()
 }
 
-pub fn created_at2() -> NaiveDateTime {
+pub fn created_at2() -> DateTime<Utc> {
     later_timestamp()
 }

--- a/crates/infrastructure/src/lib.rs
+++ b/crates/infrastructure/src/lib.rs
@@ -18,6 +18,10 @@ impl RepositoriesImpl {
     }
 
     /// Initializes the SeaORM connection. Implicitly depends on a tracing subscriber already being set up so logging can emit.
+    ///
+    /// # Panics
+    /// Panics if database connection fails. This is appropriate for startup as the application
+    /// cannot function without a database connection.
     #[instrument(name = "infrastructure.repositories.new_default", skip(db_url))]
     pub async fn new_default(db_url: &str) -> Self {
         info!("Connecting to database via SeaORM");

--- a/crates/infrastructure/src/model/record.rs
+++ b/crates/infrastructure/src/model/record.rs
@@ -8,7 +8,7 @@ use crate::entities::{
 };
 
 /// Converts database record model to domain entity.
-/// 
+///
 /// # Errors
 /// Returns `InternalError` if the database contains invalid data (negative score or play_count).
 /// This conversion assumes database integrity constraints ensure valid data.

--- a/crates/infrastructure/src/model/record.rs
+++ b/crates/infrastructure/src/model/record.rs
@@ -1,4 +1,3 @@
-use chrono::NaiveDateTime;
 use domain::entity::{clear_type::ClearType as DomainClearType, record::Record};
 
 use crate::entities::{
@@ -12,7 +11,7 @@ impl From<RecordModel> for Record {
         let sheet_id = model.sheet_id.to_string();
         let score = u32::try_from(model.score).expect("score must be non-negative");
         let play_count = u32::try_from(model.play_count).expect("play_count must be non-negative");
-        let updated_at: NaiveDateTime = model.updated_at.naive_utc();
+        let updated_at = model.updated_at.with_timezone(&chrono::Utc);
 
         Record::new(
             id,

--- a/crates/infrastructure/src/model/record.rs
+++ b/crates/infrastructure/src/model/record.rs
@@ -1,19 +1,35 @@
+use anyhow::Error as AnyError;
 use domain::entity::{clear_type::ClearType as DomainClearType, record::Record};
+use domain::repository::record::RecordRepositoryError;
+use std::convert::TryFrom;
 
 use crate::entities::{
     records::Model as RecordModel, sea_orm_active_enums::ClearType as DbClearType,
 };
 
-impl From<RecordModel> for Record {
-    fn from(model: RecordModel) -> Self {
+/// Converts database record model to domain entity.
+/// 
+/// # Errors
+/// Returns `InternalError` if the database contains invalid data (negative score or play_count).
+/// This conversion assumes database integrity constraints ensure valid data.
+impl TryFrom<RecordModel> for Record {
+    type Error = RecordRepositoryError;
+
+    fn try_from(model: RecordModel) -> Result<Self, Self::Error> {
         let id = model.id.to_string();
         let user_id = model.user_id.to_string();
         let sheet_id = model.sheet_id.to_string();
-        let score = u32::try_from(model.score).expect("score must be non-negative");
-        let play_count = u32::try_from(model.play_count).expect("play_count must be non-negative");
+        let score = u32::try_from(model.score).map_err(|err| {
+            tracing::warn!(error = %err, value = model.score, "Score from database must be non-negative");
+            RecordRepositoryError::InternalError(AnyError::from(err))
+        })?;
+        let play_count = u32::try_from(model.play_count).map_err(|err| {
+            tracing::warn!(error = %err, value = model.play_count, "Play count from database must be non-negative");
+            RecordRepositoryError::InternalError(AnyError::from(err))
+        })?;
         let updated_at = model.updated_at.with_timezone(&chrono::Utc);
 
-        Record::new(
+        Ok(Record::new(
             id,
             user_id,
             sheet_id,
@@ -21,7 +37,7 @@ impl From<RecordModel> for Record {
             model.clear_type.into(),
             play_count,
             updated_at,
-        )
+        ))
     }
 }
 

--- a/crates/infrastructure/src/record/adapter.rs
+++ b/crates/infrastructure/src/record/adapter.rs
@@ -69,44 +69,44 @@ pub fn parse_sheet_uuid(sheet_id: &str) -> Result<Uuid, RecordRepositoryError> {
 
 fn parse_record_uuid(record_id: &str) -> Result<Uuid, RecordRepositoryError> {
     Uuid::parse_str(record_id).map_err(|err| {
-        tracing::error!(error = %err, "Failed to parse record id");
+        tracing::debug!(error = %err, "Failed to parse record id");
         RecordRepositoryError::InternalError(AnyError::from(err))
     })
 }
 
 pub fn convert_level(raw_level: i32) -> Result<Level, RecordRepositoryError> {
     if raw_level < 0 {
-        tracing::error!(value = raw_level, "Level must be non-negative");
+        tracing::warn!(value = raw_level, "Level must be non-negative");
         return Err(RecordRepositoryError::InternalError(AnyError::msg(
             "negative level encountered",
         )));
     }
 
     let integer = u32::try_from(raw_level / 10).map_err(|err| {
-        tracing::error!(error = %err, value = raw_level, "Failed to convert level integer part");
+        tracing::warn!(error = %err, value = raw_level, "Failed to convert level integer part");
         RecordRepositoryError::InternalError(AnyError::from(err))
     })?;
     let decimal = u32::try_from(raw_level % 10).map_err(|err| {
-        tracing::error!(error = %err, value = raw_level, "Failed to convert level decimal part");
+        tracing::warn!(error = %err, value = raw_level, "Failed to convert level decimal part");
         RecordRepositoryError::InternalError(AnyError::from(err))
     })?;
 
     Level::new(integer, decimal).map_err(|err| {
-        tracing::error!(error = ?err, value = raw_level, "Invalid level value returned from database");
+        tracing::warn!(error = ?err, value = raw_level, "Invalid level value returned from database");
         RecordRepositoryError::InternalError(AnyError::from(err))
     })
 }
 
 fn convert_score(score: u32) -> Result<i32, RecordRepositoryError> {
     i32::try_from(score).map_err(|err| {
-        tracing::error!(error = %err, "Score exceeds database range");
+        tracing::warn!(error = %err, "Score exceeds database range");
         RecordRepositoryError::InternalError(AnyError::from(err))
     })
 }
 
 fn convert_play_count(play_count: u32) -> Result<i32, RecordRepositoryError> {
     i32::try_from(play_count).map_err(|err| {
-        tracing::error!(error = %err, "Play count exceeds database range");
+        tracing::warn!(error = %err, "Play count exceeds database range");
         RecordRepositoryError::InternalError(AnyError::from(err))
     })
 }

--- a/crates/infrastructure/src/record/adapter.rs
+++ b/crates/infrastructure/src/record/adapter.rs
@@ -1,5 +1,4 @@
 use anyhow::Error as AnyError;
-use chrono::{TimeZone, Utc};
 use domain::{
     entity::{level::Level, record::Record},
     repository::record::RecordRepositoryError,
@@ -32,7 +31,7 @@ pub fn active_model_for_insert(
         score: ActiveValue::Set(convert_score(*record.score())?),
         clear_type: ActiveValue::Set(DbClearType::from(*record.clear_type())),
         play_count: ActiveValue::Set(convert_play_count(*record.play_count())?),
-        updated_at: ActiveValue::Set(Utc.from_utc_datetime(record.updated_at()).into()),
+        updated_at: ActiveValue::Set((*record.updated_at()).into()),
     })
 }
 
@@ -50,7 +49,7 @@ pub fn active_model_for_update(
         score: ActiveValue::Set(convert_score(*record.score())?),
         clear_type: ActiveValue::Set(DbClearType::from(*record.clear_type())),
         play_count: ActiveValue::Set(convert_play_count(*record.play_count())?),
-        updated_at: ActiveValue::Set(Utc.from_utc_datetime(record.updated_at()).into()),
+        updated_at: ActiveValue::Set((*record.updated_at()).into()),
     })
 }
 

--- a/crates/infrastructure/src/record/mod.rs
+++ b/crates/infrastructure/src/record/mod.rs
@@ -10,9 +10,7 @@ use sea_orm::DbConn;
 use std::sync::Arc;
 use tracing::{debug, info, instrument};
 
-use read::{
-    records_by_user, records_by_user_and_sheet_ids, records_with_metadata_by_user,
-};
+use read::{records_by_user, records_by_user_and_sheet_ids, records_with_metadata_by_user};
 
 pub struct RecordRepositoryImpl {
     db: Arc<DbConn>,
@@ -58,7 +56,10 @@ impl RecordRepository for RecordRepositoryImpl {
     ) -> Result<Vec<Record>, RecordRepositoryError> {
         debug!("Fetching records by sheet IDs via SeaORM");
         let records = records_by_user_and_sheet_ids(self.db.as_ref(), user_id, sheet_ids).await?;
-        info!(count = records.len(), "Records by sheet IDs fetched successfully");
+        info!(
+            count = records.len(),
+            "Records by sheet IDs fetched successfully"
+        );
         Ok(records)
     }
 

--- a/crates/infrastructure/src/record/read.rs
+++ b/crates/infrastructure/src/record/read.rs
@@ -5,7 +5,7 @@ use domain::{
     entity::record::Record,
     repository::record::{RecordRepositoryError, RecordWithMetadata},
 };
-use sea_orm::{ColumnTrait, DbConn, EntityTrait, QueryFilter, prelude::Uuid};
+use sea_orm::{ColumnTrait, DbConn, EntityTrait, QueryFilter, QueryOrder, prelude::Uuid};
 use tracing::{debug, error};
 
 use crate::entities::{self, prelude::Records};
@@ -19,6 +19,7 @@ pub async fn records_by_user(
 
     let models = Records::find()
         .filter(entities::records::Column::UserId.eq(uuid))
+        .order_by_asc(entities::records::Column::UpdatedAt)
         .all(db)
         .await
         .map_err(|err| {
@@ -65,6 +66,7 @@ async fn records_with_metadata(
     let records_and_sheets = entities::records::Entity::find()
         .filter(entities::records::Column::UserId.eq(user_uuid))
         .find_also_related(entities::sheets::Entity)
+        .order_by_asc(entities::records::Column::UpdatedAt)
         .all(db)
         .await
         .map_err(|err| {
@@ -88,6 +90,7 @@ async fn records_with_metadata(
             .filter(
                 entities::musics::Column::Id.is_in(music_ids.iter().copied().collect::<Vec<_>>()),
             )
+            .order_by_asc(entities::musics::Column::Id)
             .all(db)
             .await
             .map_err(|err| {

--- a/crates/infrastructure/src/record/read.rs
+++ b/crates/infrastructure/src/record/read.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::convert::TryFrom;
 
 use anyhow::Error as AnyError;
 use domain::{
@@ -27,7 +28,7 @@ pub async fn records_by_user(
             RecordRepositoryError::InternalError(AnyError::from(err))
         })?;
 
-    Ok(models.into_iter().map(Record::from).collect())
+    models.into_iter().map(Record::try_from).collect()
 }
 
 pub async fn records_by_user_and_sheet_ids(
@@ -59,7 +60,7 @@ pub async fn records_by_user_and_sheet_ids(
             RecordRepositoryError::InternalError(AnyError::from(err))
         })?;
 
-    Ok(models.into_iter().map(Record::from).collect())
+    models.into_iter().map(Record::try_from).collect()
 }
 
 pub async fn records_with_metadata_by_user(
@@ -149,7 +150,7 @@ async fn records_with_metadata(
         })?;
 
         let level = crate::record::adapter::convert_level(sheet.level)?;
-        let record = domain::entity::record::Record::from(record_model);
+        let record = Record::try_from(record_model)?;
         result.push(RecordWithMetadata::new(record, level, is_test));
     }
 

--- a/crates/infrastructure/src/record/read.rs
+++ b/crates/infrastructure/src/record/read.rs
@@ -6,7 +6,7 @@ use domain::{
     repository::record::{RecordRepositoryError, RecordWithMetadata},
 };
 use sea_orm::{ColumnTrait, DbConn, EntityTrait, QueryFilter, QueryOrder, prelude::Uuid};
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 
 use crate::entities::{self, prelude::Records};
 
@@ -77,7 +77,7 @@ async fn records_with_metadata(
     let mut music_ids = HashSet::new();
     for (record_model, sheet_model) in &records_and_sheets {
         let sheet = sheet_model.as_ref().ok_or_else(|| {
-            error!(sheet_id = %record_model.sheet_id, "Sheet missing while loading records");
+            warn!(sheet_id = %record_model.sheet_id, "Sheet missing while loading records");
             RecordRepositoryError::SheetNotFound(record_model.sheet_id.to_string())
         })?;
         music_ids.insert(sheet.music_id);
@@ -107,12 +107,12 @@ async fn records_with_metadata(
     let mut result = Vec::with_capacity(records_and_sheets.len());
     for (record_model, sheet_model) in records_and_sheets {
         let sheet = sheet_model.ok_or_else(|| {
-            error!(sheet_id = %record_model.sheet_id, "Sheet missing while composing metadata");
+            warn!(sheet_id = %record_model.sheet_id, "Sheet missing while composing metadata");
             RecordRepositoryError::SheetNotFound(record_model.sheet_id.to_string())
         })?;
 
         let is_test = music_map.get(&sheet.music_id).copied().ok_or_else(|| {
-            error!(music_id = %sheet.music_id, "Music metadata missing for sheet");
+            warn!(music_id = %sheet.music_id, "Music metadata missing for sheet");
             RecordRepositoryError::SheetNotFound(sheet.id.to_string())
         })?;
 

--- a/crates/infrastructure/src/record/write.rs
+++ b/crates/infrastructure/src/record/write.rs
@@ -1,3 +1,5 @@
+use std::convert::TryFrom;
+
 use domain::{entity::record::Record, repository::record::RecordRepositoryError};
 use sea_orm::{ActiveModelTrait, DbConn};
 
@@ -11,7 +13,7 @@ pub async fn insert_record(db: &DbConn, record: Record) -> Result<Record, Record
     let active = active_model_for_insert(&record)?;
 
     match active.insert(db).await {
-        Ok(model) => Ok(model.into()),
+        Ok(model) => Ok(Record::try_from(model)?),
         Err(err) => Err(convert_insert_error(err, &user_id, &sheet_id)),
     }
 }
@@ -21,7 +23,7 @@ pub async fn update_record(db: &DbConn, record: Record) -> Result<Record, Record
     let active = active_model_for_update(&record)?;
 
     match active.update(db).await {
-        Ok(model) => Ok(model.into()),
+        Ok(model) => Ok(Record::try_from(model)?),
         Err(err) => Err(convert_update_error(err, &record_id)),
     }
 }

--- a/crates/infrastructure/src/record/write.rs
+++ b/crates/infrastructure/src/record/write.rs
@@ -1,6 +1,5 @@
 use domain::{entity::record::Record, repository::record::RecordRepositoryError};
 use sea_orm::{ActiveModelTrait, DbConn};
-use tracing::error;
 
 use crate::record::adapter::{
     active_model_for_insert, active_model_for_update, convert_insert_error, convert_update_error,
@@ -13,10 +12,7 @@ pub async fn insert_record(db: &DbConn, record: Record) -> Result<Record, Record
 
     match active.insert(db).await {
         Ok(model) => Ok(model.into()),
-        Err(err) => {
-            error!(error = %err, "Failed to insert record");
-            Err(convert_insert_error(err, &user_id, &sheet_id))
-        }
+        Err(err) => Err(convert_insert_error(err, &user_id, &sheet_id)),
     }
 }
 
@@ -26,9 +22,6 @@ pub async fn update_record(db: &DbConn, record: Record) -> Result<Record, Record
 
     match active.update(db).await {
         Ok(model) => Ok(model.into()),
-        Err(err) => {
-            error!(error = %err, "Failed to update record");
-            Err(convert_update_error(err, &record_id))
-        }
+        Err(err) => Err(convert_update_error(err, &record_id)),
     }
 }

--- a/crates/infrastructure/src/user/adapter.rs
+++ b/crates/infrastructure/src/user/adapter.rs
@@ -1,20 +1,23 @@
 use anyhow::Error as AnyError;
 use domain::repository::user::UserRepositoryError;
 use sea_orm::{DbErr, error::SqlErr, prelude::Uuid};
-use tracing::debug;
+use tracing::{debug, error, warn};
 
 /// Map SeaORM insertion errors into domain-specific variants to preserve invariants.
 pub fn convert_user_insert_error(err: DbErr, card: &str) -> UserRepositoryError {
     if matches!(err, DbErr::RecordNotInserted) {
+        warn!(card = %card, "Card ID already exists");
         return UserRepositoryError::CardIdAlreadyExists(card.to_owned());
     }
 
     if let Some(sql_err) = err.sql_err()
         && matches!(sql_err, SqlErr::UniqueConstraintViolation(_))
     {
+        warn!(card = %card, "Unique constraint violation for card ID");
         return UserRepositoryError::CardIdAlreadyExists(card.to_owned());
     }
 
+    error!(error = %err, "Failed to insert user");
     UserRepositoryError::InternalError(AnyError::from(err))
 }
 

--- a/crates/infrastructure/src/user/read.rs
+++ b/crates/infrastructure/src/user/read.rs
@@ -1,3 +1,5 @@
+use std::convert::TryFrom;
+
 use anyhow::Error as AnyError;
 use domain::{entity::user::User, repository::user::UserRepositoryError};
 use sea_orm::{ColumnTrait, DbConn, EntityTrait, QueryFilter};
@@ -18,7 +20,7 @@ pub async fn find_by_card(db: &DbConn, card: &str) -> Result<Option<User>, UserR
 
     if let Some(model) = model {
         info!(user_id = %model.id, "User fetched successfully");
-        Ok(Some(model.into()))
+        Ok(Some(User::try_from(model)?))
     } else {
         debug!("User not found for supplied card");
         Ok(None)
@@ -36,5 +38,5 @@ pub async fn find_by_id(db: &DbConn, user_id: &str) -> Result<Option<User>, User
             UserRepositoryError::InternalError(AnyError::from(err))
         })?;
 
-    Ok(model.map(Into::into))
+    model.map(User::try_from).transpose()
 }

--- a/crates/infrastructure/src/user/write.rs
+++ b/crates/infrastructure/src/user/write.rs
@@ -1,3 +1,5 @@
+use std::convert::TryFrom;
+
 use anyhow::Error as AnyError;
 use domain::{entity::user::User, repository::user::UserRepositoryError};
 use sea_orm::{
@@ -18,7 +20,7 @@ pub async fn create_user(db: &DbConn, user: User) -> Result<User, UserRepository
         .map_err(|err| convert_user_insert_error(err, &card_id))?;
 
     debug!(user_id = %db_user_model.id, "User persisted by repository");
-    Ok(db_user_model.into())
+    User::try_from(db_user_model)
 }
 
 pub async fn increment_credits(db: &DbConn, user_id: &str) -> Result<(), UserRepositoryError> {
@@ -59,5 +61,5 @@ pub async fn save_user(db: &DbConn, user: User) -> Result<User, UserRepositoryEr
     })?;
 
     info!(user_id = %model.id, "User updated successfully");
-    Ok(model.into())
+    User::try_from(model)
 }

--- a/crates/infrastructure/src/user/write.rs
+++ b/crates/infrastructure/src/user/write.rs
@@ -12,10 +12,10 @@ pub async fn create_user(db: &DbConn, user: User) -> Result<User, UserRepository
     let card_id = user.card().to_owned();
     let db_user: entities::users::ActiveModel = user.into();
 
-    let db_user_model = db_user.insert(db).await.map_err(|err| {
-        error!(error = %err, "Failed to insert user");
-        convert_user_insert_error(err, &card_id)
-    })?;
+    let db_user_model = db_user
+        .insert(db)
+        .await
+        .map_err(|err| convert_user_insert_error(err, &card_id))?;
 
     debug!(user_id = %db_user_model.id, "User persisted by repository");
     Ok(db_user_model.into())
@@ -33,7 +33,7 @@ pub async fn increment_credits(db: &DbConn, user_id: &str) -> Result<(), UserRep
         .exec(db)
         .await
         .map_err(|err| {
-            error!(error = %err, "Failed to increment user credits");
+            error!(error = %err, user_id = %uuid, "Failed to increment user credits");
             UserRepositoryError::InternalError(AnyError::from(err))
         })?;
 
@@ -54,7 +54,7 @@ pub async fn save_user(db: &DbConn, user: User) -> Result<User, UserRepositoryEr
     active.id = ActiveValue::Set(uuid);
 
     let model = active.update(db).await.map_err(|err| {
-        error!(error = %err, "Failed to update user");
+        error!(error = %err, user_id = %uuid, "Failed to update user");
         UserRepositoryError::InternalError(AnyError::from(err))
     })?;
 

--- a/crates/migration/src/m20251007_000004_create_records_table.rs
+++ b/crates/migration/src/m20251007_000004_create_records_table.rs
@@ -26,7 +26,13 @@ impl MigrationTrait for Migration {
                 Table::create()
                     .table(Records::Table)
                     .if_not_exists()
-                    .col(ColumnDef::new(Records::Id).uuid().not_null().primary_key())
+                    .col(
+                        ColumnDef::new(Records::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key()
+                            .default(Expr::cust("gen_random_uuid()")),
+                    )
                     .col(ColumnDef::new(Records::UserId).uuid().not_null())
                     .col(ColumnDef::new(Records::SheetId).uuid().not_null())
                     .col(ColumnDef::new(Records::Score).integer().not_null())

--- a/crates/presentation/src/model/user.rs
+++ b/crates/presentation/src/model/user.rs
@@ -5,6 +5,7 @@ use usecase::model::user::{
 };
 
 #[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct RegisterUserRequest {
     pub card: String,
     pub display_name: String,
@@ -28,6 +29,7 @@ impl From<RegisterUserRequest> for UserRegisterDto {
 }
 
 #[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct UserDataResponse {
     pub id: String,
     pub card: String,
@@ -93,16 +95,13 @@ impl From<UserCreditsDto> for CreditsIncrementResponse {
 }
 
 #[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct UserRecordResponse {
     pub id: String,
-    #[serde(rename = "sheetId")]
     pub sheet_id: String,
     pub score: u32,
-    #[serde(rename = "clearType")]
     pub clear_type: String,
-    #[serde(rename = "playCount")]
     pub play_count: u32,
-    #[serde(rename = "updatedAt")]
     pub updated_at: String,
 }
 
@@ -128,13 +127,11 @@ impl From<UserRecordDto> for UserRecordResponse {
 }
 
 #[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct UserRecordRequest {
-    #[serde(rename = "userId")]
     pub user_id: String,
-    #[serde(rename = "sheetId")]
     pub sheet_id: String,
     pub score: u32,
-    #[serde(rename = "clearType")]
     pub clear_type: String,
 }
 

--- a/crates/presentation/src/model/user.rs
+++ b/crates/presentation/src/model/user.rs
@@ -74,7 +74,7 @@ impl From<UserDataDto> for UserDataResponse {
             user_data.xp,
             user_data.credits,
             user_data.is_admin,
-            user_data.created_at.to_string(),
+            user_data.created_at.to_rfc3339(),
         )
     }
 }
@@ -122,7 +122,7 @@ impl From<UserRecordDto> for UserRecordResponse {
             score: dto.score,
             clear_type,
             play_count: dto.play_count,
-            updated_at: dto.updated_at.to_string(),
+            updated_at: dto.updated_at.to_rfc3339(),
         }
     }
 }

--- a/crates/presentation/src/route/user.rs
+++ b/crates/presentation/src/route/user.rs
@@ -433,9 +433,11 @@ mod tests {
     async fn handle_post_records_returns_created() {
         let mut record_repo = MockRecordRepository::new();
         record_repo
-            .expect_find_by_user_id()
-            .withf(|user_id| user_id == USER1.id)
-            .returning(|_| Box::pin(async { Ok(Vec::new()) }));
+            .expect_find_by_user_id_and_sheet_ids()
+            .withf(|user_id, sheet_ids| {
+                user_id == USER1.id && sheet_ids.len() == 1 && sheet_ids[0] == "sheet-1"
+            })
+            .returning(|_, _| Box::pin(async { Ok(Vec::new()) }));
         record_repo
             .expect_insert()
             .withf(|record| record.user_id() == USER1.id && record.sheet_id() == "sheet-1")

--- a/crates/presentation/src/route/user.rs
+++ b/crates/presentation/src/route/user.rs
@@ -173,7 +173,7 @@ mod tests {
 
         let payload = json!({
             "card": USER2.card,
-            "display_name": USER2.display_name
+            "displayName": USER2.display_name
         });
 
         let response = router
@@ -192,12 +192,12 @@ mod tests {
         let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(json["id"], USER2.id);
         assert_eq!(json["card"], USER2.card);
-        assert_eq!(json["display_name"], USER2.display_name);
+        assert_eq!(json["displayName"], USER2.display_name);
         assert_eq!(json["rating"], USER2.rating);
         assert_eq!(json["xp"], USER2.xp);
         assert_eq!(json["credits"], USER2.credits);
-        assert_eq!(json["is_admin"], false);
-        assert_eq!(json["created_at"], "2025-10-21T15:00:00+00:00");
+        assert_eq!(json["isAdmin"], false);
+        assert_eq!(json["createdAt"], "2025-10-21T15:00:00+00:00");
     }
 
     #[tokio::test]
@@ -215,7 +215,7 @@ mod tests {
 
         let payload = json!({
             "card": USER2.card,
-            "display_name": USER1.display_name
+            "displayName": USER1.display_name
         });
 
         let response = router
@@ -268,7 +268,7 @@ mod tests {
         let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(json["id"], USER1.id);
         assert_eq!(json["card"], USER1.card);
-        assert_eq!(json["display_name"], USER1.display_name);
+        assert_eq!(json["displayName"], USER1.display_name);
     }
 
     #[tokio::test]

--- a/crates/presentation/src/route/user.rs
+++ b/crates/presentation/src/route/user.rs
@@ -111,7 +111,6 @@ mod tests {
         body::{self, Body},
         http::Request,
     };
-    use chrono::NaiveDate;
     use domain::entity::rating::Rating;
     use domain::{
         entity::{clear_type::ClearType, level::Level, record::Record, user::User},
@@ -141,11 +140,12 @@ mod tests {
         super::super::create_app(state)
     }
 
-    fn sample_timestamp() -> chrono::NaiveDateTime {
-        NaiveDate::from_ymd_opt(2025, 10, 26)
+    fn sample_timestamp() -> chrono::DateTime<chrono::Utc> {
+        chrono::NaiveDate::from_ymd_opt(2025, 10, 26)
             .unwrap()
             .and_hms_opt(12, 0, 0)
             .unwrap()
+            .and_utc()
     }
 
     #[tokio::test]
@@ -197,7 +197,7 @@ mod tests {
         assert_eq!(json["xp"], USER2.xp);
         assert_eq!(json["credits"], USER2.credits);
         assert_eq!(json["is_admin"], false);
-        assert_eq!(json["created_at"], "2025-10-21 15:00:00");
+        assert_eq!(json["created_at"], "2025-10-21T15:00:00+00:00");
     }
 
     #[tokio::test]
@@ -363,10 +363,11 @@ mod tests {
                         1_000_000,
                         ClearType::Clear,
                         5,
-                        NaiveDate::from_ymd_opt(2025, 10, 26)
+                        chrono::NaiveDate::from_ymd_opt(2025, 10, 26)
                             .unwrap()
                             .and_hms_opt(12, 0, 0)
-                            .unwrap(),
+                            .unwrap()
+                            .and_utc(),
                     )])
                 })
             });

--- a/crates/usecase/src/model/user.rs
+++ b/crates/usecase/src/model/user.rs
@@ -1,4 +1,4 @@
-use chrono::NaiveDateTime;
+use chrono::{DateTime, Utc};
 use domain::entity::{clear_type::ClearType, record::Record, user::User};
 
 #[derive(Debug)]
@@ -22,7 +22,7 @@ pub struct UserDataDto {
     pub xp: u32,
     pub credits: u32,
     pub is_admin: bool,
-    pub created_at: NaiveDateTime,
+    pub created_at: DateTime<Utc>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -35,7 +35,7 @@ impl UserDataDto {
         xp: u32,
         credits: u32,
         is_admin: bool,
-        created_at: NaiveDateTime,
+        created_at: DateTime<Utc>,
     ) -> Self {
         Self {
             id,
@@ -83,7 +83,7 @@ pub struct UserRecordDto {
     pub score: u32,
     pub clear_type: ClearType,
     pub play_count: u32,
-    pub updated_at: NaiveDateTime,
+    pub updated_at: DateTime<Utc>,
 }
 
 #[derive(Debug, Clone)]
@@ -110,7 +110,7 @@ impl UserRecordDto {
         score: u32,
         clear_type: ClearType,
         play_count: u32,
-        updated_at: NaiveDateTime,
+        updated_at: DateTime<Utc>,
     ) -> Self {
         Self {
             id,

--- a/crates/usecase/src/user/records.rs
+++ b/crates/usecase/src/user/records.rs
@@ -77,7 +77,7 @@ impl<R: Repositories> UserUsecase<R> {
         for submission in submissions {
             let sheet_id = submission.sheet_id.clone();
             xp_delta = xp_delta.saturating_add(experience::xp_for_score(submission.score));
-            let submitted_at = Utc::now().naive_utc();
+            let submitted_at = Utc::now();
 
             match record_map.remove(&sheet_id) {
                 Some(mut record) => {
@@ -148,7 +148,6 @@ impl<R: Repositories> UserUsecase<R> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::NaiveDate;
     use domain::{
         entity::rating::Rating,
         entity::{clear_type::ClearType, level::Level, record::Record, user::User},
@@ -160,11 +159,12 @@ mod tests {
     };
     use std::sync::Arc;
 
-    fn sample_timestamp() -> chrono::NaiveDateTime {
-        NaiveDate::from_ymd_opt(2025, 10, 26)
+    fn sample_timestamp() -> chrono::DateTime<chrono::Utc> {
+        chrono::NaiveDate::from_ymd_opt(2025, 10, 26)
             .unwrap()
             .and_hms_opt(9, 30, 0)
             .unwrap()
+            .and_utc()
     }
 
     #[tokio::test]


### PR DESCRIPTION
- `record` の UUID を DB 側で採番するように
- 複数のレコードが返ってくるクエリは order by で冪等性を保つように
- `DateTime<Utc>` に統一してタイムゾーン情報を保持し、API返却はRFC3339にする
- ログレベルの使用基準を以下に統一
  - info: 本番で出す情報（ビジネスイベント、ライフサイクル）
  - debug: デバッグ用の技術詳細（開発時の調査のみ）
  - warn: 監視対象の異常（データ整合性、ビジネスロジックエラー）
  - error: 運用対応が必要な深刻な障害（DB接続エラーなど）
- infrastructure 層の `From` トレイトで `panic` や `expect` を使用せず、`TryFrom` で `Result` を返すように
- json 向けに `#[serde(rename_all = "camelCase")]` を使用するリファクタ
- `crates/usecase/src/user/records.rs` でレコードを全権取得せずクエリを厳密にしてパフォーマンスを向上
---

### タイムゾーンに関するリファクタの詳細

- `DateTime<Utc>` に統一してタイムゾーン情報を保持し、API返却はRFC3339にする

**リファクタ前**
- データベース: `TIMESTAMPTZ`（タイムゾーン付き）
- ドメイン/DTO: `NaiveDateTime`（タイムゾーンなし）
- サーバー生成: `Utc::now().naive_utc()` で取得後に `.naive_utc()` でタイムゾーン情報を消去
```rust:crates/infrastructure/src/record/adapter.rs
updated_at: ActiveValue::Set(Utc.from_utc_datetime(record.updated_at()).into()),
```
- API レスポンス: `.to_string()` 使用で RFC3339 未対応

**リファクタ後**
- ドメイン/DTO/API をすべて `DateTime<Utc>` に統一し、レスポンスは `.to_rfc3339()` を使用
- PostgreSQL `TIMESTAMPTZ` は維持
- クライアント送信は不要で、サーバー側生成のまま（`DateTime<Utc>` に統一）
