### PR TITLE
Auth0 Deploy CLI による構成管理を追加

### DIFF
--- a/.github/workflows/auth0-deploy.yml
+++ b/.github/workflows/auth0-deploy.yml
@@ -1,0 +1,41 @@
+name: Deploy Auth0 configuration
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - auth0/**
+      - .github/workflows/auth0-deploy.yml
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy Auth0 configuration
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Auth0 Deploy CLI
+        run: npm install --global auth0-deploy-cli@8.41.0
+
+      - name: Preview and apply Auth0 configuration
+        run: |
+          a0deploy import \
+            --config_file=auth0/config.json \
+            --input_file=auth0/tenant.yaml \
+            --dry-run \
+            --apply
+        env:
+          AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
+          AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
+          AUTH0_CLIENT_SECRET: ${{ secrets.AUTH0_CLIENT_SECRET }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,154 +127,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "async-attributes"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener 2.5.3",
- "futures-core",
-]
-
-[[package]]
-name = "async-channel"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497c00e0fd83a72a79a39fcbd8e3e2f055d6f6c7e025f3b3d91f4f8e76527fb8"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand 2.3.0",
- "futures-lite 2.6.1",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
-dependencies = [
- "async-channel 2.5.0",
- "async-executor",
- "async-io 2.6.0",
- "async-lock 3.4.1",
- "blocking",
- "futures-lite 2.6.1",
- "once_cell",
- "tokio",
-]
-
-[[package]]
-name = "async-io"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
-dependencies = [
- "async-lock 2.8.0",
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-lite 1.13.0",
- "log",
- "parking",
- "polling 2.8.0",
- "rustix 0.37.28",
- "slab",
- "socket2 0.4.10",
- "waker-fn",
-]
-
-[[package]]
-name = "async-io"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
-dependencies = [
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite 2.6.1",
- "parking",
- "polling 3.11.0",
- "rustix 1.1.2",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-lock"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
-dependencies = [
- "event-listener 2.5.3",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
-dependencies = [
- "event-listener 5.4.1",
- "event-listener-strategy",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-std"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
-dependencies = [
- "async-attributes",
- "async-channel 1.9.0",
- "async-global-executor",
- "async-io 2.6.0",
- "async-lock 3.4.1",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite 2.6.1",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,12 +149,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
-
-[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,12 +167,6 @@ checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
 dependencies = [
  "num-traits",
 ]
-
-[[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -431,12 +271,6 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
@@ -463,19 +297,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "blocking"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
-dependencies = [
- "async-channel 2.5.0",
- "async-task",
- "futures-io",
- "futures-lite 2.6.1",
- "piper",
 ]
 
 [[package]]
@@ -810,16 +631,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "errno"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "etcetera"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -832,12 +643,6 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
@@ -846,31 +651,6 @@ dependencies = [
  "parking",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
-dependencies = [
- "event-listener 5.4.1",
- "pin-project-lite",
-]
-
-[[package]]
-name = "fastrand"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
-
-[[package]]
-name = "fastrand"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "flume"
@@ -975,34 +755,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
-name = "futures-lite"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
-dependencies = [
- "fastrand 1.9.0",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite",
- "waker-fn",
-]
-
-[[package]]
-name = "futures-lite"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
-dependencies = [
- "fastrand 2.3.0",
- "futures-core",
- "futures-io",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,18 +828,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
-name = "gloo-timers"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1133,18 +873,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1431,32 +1159,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi 0.3.9",
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "io-uring"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "cfg-if",
  "libc",
 ]
@@ -1481,15 +1189,6 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
 ]
 
 [[package]]
@@ -1519,7 +1218,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "libc",
  "redox_syscall",
 ]
@@ -1533,18 +1232,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -1567,9 +1254,6 @@ name = "log"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
-dependencies = [
- "value-bag",
-]
 
 [[package]]
 name = "matchers"
@@ -1606,8 +1290,8 @@ checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 name = "migration"
 version = "0.1.0"
 dependencies = [
- "async-std",
  "sea-orm-migration",
+ "tokio",
 ]
 
 [[package]]
@@ -1854,17 +1538,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "piper"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
-dependencies = [
- "atomic-waker",
- "fastrand 2.3.0",
- "futures-io",
-]
-
-[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1890,36 +1563,6 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "polling"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
-dependencies = [
- "autocfg",
- "bitflags 1.3.2",
- "cfg-if",
- "concurrent-queue",
- "libc",
- "log",
- "pin-project-lite",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "polling"
-version = "3.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi 0.5.2",
- "pin-project-lite",
- "rustix 1.1.2",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "potential_utf"
@@ -2116,7 +1759,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -2243,33 +1886,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
-name = "rustix"
-version = "0.37.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "519165d378b97752ca44bbe15047d5d3409e875f39327546b42ac81d7e18c1b6"
-dependencies = [
- "bitflags 1.3.2",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.3.8",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "rustix"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
-dependencies = [
- "bitflags 2.9.1",
- "errno",
- "libc",
- "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "rustls"
 version = "0.23.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2369,7 +1985,6 @@ version = "1.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6d4ff77d7c27f64942273513e7c103a1594c88deba33dfb2f490b362ea220b4"
 dependencies = [
- "async-std",
  "chrono",
  "clap",
  "dotenvy",
@@ -2377,6 +1992,7 @@ dependencies = [
  "regex",
  "sea-schema",
  "sqlx",
+ "tokio",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -2633,16 +2249,6 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
@@ -2689,8 +2295,6 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
- "async-io 1.13.0",
- "async-std",
  "base64",
  "bigdecimal",
  "bytes",
@@ -2698,7 +2302,7 @@ dependencies = [
  "crc",
  "crossbeam-queue",
  "either",
- "event-listener 5.4.1",
+ "event-listener",
  "futures-core",
  "futures-intrusive",
  "futures-io",
@@ -2745,7 +2349,6 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
 dependencies = [
- "async-std",
  "dotenvy",
  "either",
  "heck 0.5.0",
@@ -2774,7 +2377,7 @@ dependencies = [
  "atoi",
  "base64",
  "bigdecimal",
- "bitflags 2.9.1",
+ "bitflags",
  "byteorder",
  "bytes",
  "chrono",
@@ -2821,7 +2424,7 @@ dependencies = [
  "atoi",
  "base64",
  "bigdecimal",
- "bitflags 2.9.1",
+ "bitflags",
  "byteorder",
  "chrono",
  "crc",
@@ -3074,7 +2677,7 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "socket2 0.6.0",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.59.0",
 ]
@@ -3153,7 +2756,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "bytes",
  "http",
  "http-body",
@@ -3329,12 +2932,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
-name = "value-bag"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943ce29a8a743eb10d6082545d861b24f9d1b160b7d741e0f2cdf726bec909c5"
-
-[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3345,12 +2942,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "waker-fn"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
 
 [[package]]
 name = "wasi"
@@ -3391,19 +2982,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
-dependencies = [
- "cfg-if",
- "js-sys",
- "once_cell",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3436,16 +3014,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.77"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3472,28 +3040,6 @@ dependencies = [
  "libredox",
  "wasite",
 ]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ members = [
 
 [workspace.dependencies]
 anyhow = "1.0.95"
-async-std = "1.13"
 axum = "0.8.4"
 bigdecimal = "0.4"
 chrono = { version = "0.4.39", features = ["serde", "clock"] }
@@ -32,7 +31,7 @@ sea-orm = { version = "1.1.16", features = [
 sea-orm-migration = { version = "1.1.0", features = [
     # https://www.sea-ql.org/SeaORM/docs/install-and-config/database-and-async-runtime/
     "sqlx-postgres",
-    "runtime-async-std-rustls",
+    "runtime-tokio-rustls",
     "with-chrono",
     "with-uuid",
 ] }

--- a/auth0/README.md
+++ b/auth0/README.md
@@ -41,6 +41,33 @@ Deploy CLI 用の Auth0 Management API client は構成管理専用とし、こ�
 
 `auth0/` 以下の変更が `main` に反映されると、GitHub Actions が構成を自動適用します。削除は `AUTH0_ALLOW_DELETE=false` により無効にしています。
 
+## GitHub Actions の初期設定
+
+最初に、Auth0 Dashboard で Deploy CLI 専用の M2M Application を 1 つ作成します。この Application は Auth0 Management API を操作するためのもので、共有 M2M Application（筐体用）とは別です。
+
+Deploy CLI が管理するリソースに必要な Management API の権限を付与し、次の値を GitHub repository の Actions secrets に登録します。
+
+```text
+AUTH0_DOMAIN=dev-2dn3mvmvr8tccoss.us.auth0.com
+AUTH0_CLIENT_ID=<Deploy CLI 用 client ID>
+AUTH0_CLIENT_SECRET=<Deploy CLI 用 client secret>
+```
+
+現時点の構成には Resource Server と Role が含まれるため、Management API には少なくとも次の権限が必要です。
+
+```text
+read:resource_servers
+create:resource_servers
+update:resource_servers
+read:roles
+create:roles
+update:roles
+```
+
+Deploy CLI は client の存在確認にも `read:clients` を使用します。後続の構成で Application と client grant を管理する際は、`clients` と `client_grants` に対する read/create/update 権限を追加します。削除権限は付与しません。
+
+共有 M2M Application と dashboard 用 Regular Web Application は、Deploy CLI 用 Application の準備後に構成ファイルへ追加します。
+
 ## 構成モデル
 
 XLAIR API では、主体の大分類として次の permission を使用します。

--- a/auth0/README.md
+++ b/auth0/README.md
@@ -1,24 +1,24 @@
-# Auth0 configuration
+# Auth0 構成
 
-This directory contains the Auth0 Tenant configuration managed by Auth0 Deploy CLI (`a0deploy`).
+このディレクトリには、Auth0 Deploy CLI（`a0deploy`）で管理する Auth0 Tenant の構成を置きます。
 
-The repository uses one Auth0 Tenant:
+利用する Tenant は次の 1 つです。
 
 ```text
 dev-2dn3mvmvr8tccoss.us.auth0.com
 ```
 
-## Local usage
+## ローカルでの実行
 
-Install the pinned Deploy CLI version and provide the following environment variables:
+Deploy CLI をインストールし、次の環境変数を設定します。
 
 ```text
 AUTH0_DOMAIN=dev-2dn3mvmvr8tccoss.us.auth0.com
-AUTH0_CLIENT_ID=<deploy-cli-client-id>
-AUTH0_CLIENT_SECRET=<deploy-cli-client-secret>
+AUTH0_CLIENT_ID=<Deploy CLI 用 client ID>
+AUTH0_CLIENT_SECRET=<Deploy CLI 用 client secret>
 ```
 
-Preview the changes:
+変更内容の確認:
 
 ```sh
 a0deploy import \
@@ -27,7 +27,7 @@ a0deploy import \
   --dry-run
 ```
 
-Apply the changes after reviewing the preview:
+変更の適用:
 
 ```sh
 a0deploy import \
@@ -37,17 +37,17 @@ a0deploy import \
   --apply
 ```
 
-The Deploy CLI Management API client should be dedicated to configuration deployment and granted only the Management API permissions required by the resources managed here. Its credentials are supplied through the environment or CI secrets.
+Deploy CLI 用の Auth0 Management API client は構成管理専用とし、このリポジトリで管理するリソースに必要な権限だけを付与します。credentials は環境変数または CI secrets から渡します。
 
-The deployment workflow runs automatically after changes under `auth0/` reach `main`. Deletions remain disabled by `AUTH0_ALLOW_DELETE=false`.
+`auth0/` 以下の変更が `main` に反映されると、GitHub Actions が構成を自動適用します。削除は `AUTH0_ALLOW_DELETE=false` により無効にしています。
 
-## Configuration model
+## 構成モデル
 
-The XLAIR API defines two coarse permissions:
+XLAIR API では、主体の大分類として次の permission を使用します。
 
-- `admin`: administrator principal
-- `device`: device principal
+- `admin`: 管理者
+- `device`: 筐体
 
-The `admin` role contains the `admin` permission. Device access is granted to the shared M2M Application through a client grant. Endpoint and field-level authorization remains an XLAIR implementation concern.
+`admin` role には `admin` permission を設定します。`device` permission は共有 M2M Application に client grant で付与します。endpoint やフィールド単位の認可は XLAIR 側で扱います。
 
-The dashboard Application and the shared device M2M Application will be added after their callback URL and client-grant configuration are finalized.
+dashboard 用 Regular Web Application と共有 M2M Application は、次の構成作業で追加します。

--- a/auth0/README.md
+++ b/auth0/README.md
@@ -1,0 +1,53 @@
+# Auth0 configuration
+
+This directory contains the Auth0 Tenant configuration managed by Auth0 Deploy CLI (`a0deploy`).
+
+The repository uses one Auth0 Tenant:
+
+```text
+dev-2dn3mvmvr8tccoss.us.auth0.com
+```
+
+## Local usage
+
+Install the pinned Deploy CLI version and provide the following environment variables:
+
+```text
+AUTH0_DOMAIN=dev-2dn3mvmvr8tccoss.us.auth0.com
+AUTH0_CLIENT_ID=<deploy-cli-client-id>
+AUTH0_CLIENT_SECRET=<deploy-cli-client-secret>
+```
+
+Preview the changes:
+
+```sh
+a0deploy import \
+  --config_file=auth0/config.json \
+  --input_file=auth0/tenant.yaml \
+  --dry-run
+```
+
+Apply the changes after reviewing the preview:
+
+```sh
+a0deploy import \
+  --config_file=auth0/config.json \
+  --input_file=auth0/tenant.yaml \
+  --dry-run \
+  --apply
+```
+
+The Deploy CLI Management API client should be dedicated to configuration deployment and granted only the Management API permissions required by the resources managed here. Its credentials are supplied through the environment or CI secrets.
+
+The deployment workflow runs automatically after changes under `auth0/` reach `main`. Deletions remain disabled by `AUTH0_ALLOW_DELETE=false`.
+
+## Configuration model
+
+The XLAIR API defines two coarse permissions:
+
+- `admin`: administrator principal
+- `device`: device principal
+
+The `admin` role contains the `admin` permission. Device access is granted to the shared M2M Application through a client grant. Endpoint and field-level authorization remains an XLAIR implementation concern.
+
+The dashboard Application and the shared device M2M Application will be added after their callback URL and client-grant configuration are finalized.

--- a/auth0/config.json
+++ b/auth0/config.json
@@ -1,0 +1,3 @@
+{
+  "AUTH0_ALLOW_DELETE": false
+}

--- a/auth0/tenant.yaml
+++ b/auth0/tenant.yaml
@@ -1,0 +1,24 @@
+# Auth0 Deploy CLI tenant configuration.
+# Keep credentials in the CI environment, not in this file.
+
+resourceServers:
+  - name: XLAIR API
+    identifier: https://api.xlair.dev
+    signing_alg: RS256
+    token_lifetime: 3600
+    token_lifetime_for_web: 3600
+    skip_consent_for_verifiable_first_party_clients: true
+    enforce_policies: true
+    token_dialect: access_token_authz
+    scopes:
+      - value: admin
+        description: Identifies an administrator principal to XLAIR.
+      - value: device
+        description: Identifies a device principal to XLAIR.
+
+roles:
+  - name: admin
+    description: XLAIR administrator principal.
+    permissions:
+      - permission_name: admin
+        resource_server_identifier: https://api.xlair.dev

--- a/auth0/tenant.yaml
+++ b/auth0/tenant.yaml
@@ -6,8 +6,6 @@ resourceServers:
     identifier: https://api.xlair.dev
     signing_alg: RS256
     token_lifetime: 3600
-    token_lifetime_for_web: 3600
-    skip_consent_for_verifiable_first_party_clients: true
     enforce_policies: true
     token_dialect: access_token_authz
     scopes:

--- a/auth0/tenant.yaml
+++ b/auth0/tenant.yaml
@@ -10,9 +10,9 @@ resourceServers:
     token_dialect: access_token_authz
     scopes:
       - value: admin
-        description: Identifies an administrator principal to XLAIR.
+        description: Coarse-grained access class for administrator principals.
       - value: device
-        description: Identifies a device principal to XLAIR.
+        description: Coarse-grained access class for device principals.
 
 roles:
   - name: admin

--- a/crates/migration/Cargo.toml
+++ b/crates/migration/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2024"
 publish = false
 
 [dependencies]
-async-std.workspace = true
 sea-orm-migration.workspace = true
+tokio.workspace = true

--- a/crates/migration/src/main.rs
+++ b/crates/migration/src/main.rs
@@ -1,7 +1,7 @@
 use sea_orm_migration::prelude::*;
 
 // run migration with: cd crates && DATABASE_URL="<DATABASE_URL>" sea-orm-cli migrate refresh
-#[async_std::main]
+#[tokio::main]
 async fn main() {
     cli::run_cli(migration::Migrator).await;
 }

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -12,7 +12,7 @@
 - card ID を XLAIR 上のユーザー識別子として扱う
 - カードの複製による同一ユーザーとしての利用を許容する
 - 筐体認証には Auth0 M2M を使用する
-- M2M Application は筐体ごとに作成する
+- 全筐体で 1 つの M2M Application と credentials を共有する
 - 筐体 credentials に定期的な有効期限は設けない
 - 管理者・運用者の認証には Auth0 を使用する
 - OpenAPI では `userAuth` と `deviceAuth` を使用する
@@ -63,7 +63,7 @@ UserPrincipal { subject }
 
 ### 筐体
 
-筐体は筐体ごとの Auth0 M2M Application として API 用 access token を取得し、次の形式で送信する。
+筐体は共有する Auth0 M2M Application として API 用 access token を取得し、次の形式で送信する。
 
 ```http
 Authorization: Bearer <device access token>
@@ -77,27 +77,27 @@ Auth0 の user access token を `userAuth` として送信する。現時点で�
 
 ## 筐体 credentials の運用（推奨）
 
-筐体の登録時に provisioning 処理を実行し、筐体専用の Auth0 M2M Application を作成する。credential は secret manager から設置担当者または筐体へ安全に渡す。XLAIR の公開 API に credential 発行機能は設けない。
+筐体の登録時に provisioning 処理を実行し、共有する Auth0 M2M Application の credential を設置担当者または筐体へ安全に渡す。XLAIR の公開 API に credential 発行機能は設けない。
 
 client credential の定期的な失効は行わない。access token は短寿命に設定し、紛失・侵害時は Auth0 で対象 client を無効化するか、credential を rotation する。Auth0 で client を無効化しても発行済み token は有効期限まで有効なため、短寿命 token とする。
 
-credential の発行は、筐体の設置時に行う provisioning とする。公開 API からの自己登録は行わず、Auth0 Deploy CLI または Auth0 Management API を利用する管理用 provisioning 処理で M2M Application と API grant を作成する。
+credential の発行は、共有 M2M Application を初期構成する provisioning とする。公開 API からの自己登録は行わず、Auth0 Deploy CLI または Auth0 Management API を利用する管理用 provisioning 処理で M2M Application と API grant を作成する。
 
 Auth0 が利用するプランで Private Key JWT が利用できる場合は、筐体で生成した鍵ペアの公開鍵を Auth0 に登録し、秘密鍵を筐体外へ出さない方式を推奨する。利用できない場合は Client Secret を secure な provisioning 経路で筐体へ配布する。
 
 ## Auth0 の構成管理
 
-Auth0 の構成管理には Auth0 Deploy CLI（`a0deploy`）を使用する。Tenant の設定をリポジトリで管理し、import 前に dry run で変更内容を確認する。
+Auth0 の構成管理には Auth0 Deploy CLI（`a0deploy`）を使用する。Tenant の設定をリポジトリで管理し、import 前に dry run で変更内容を確認する。無料プランの制約に合わせ、Tenant は分離しない。
 
 管理対象:
 
 - XLAIR API の Resource Server
-- dashboard 用 Application
-- M2M Application
+- dashboard 用 Regular Web Application
+- 筐体で共有する M2M Application
 - `admin` / `device` の role、permission、client grant
 - Tenant、Connection、Action の設定
 
-Deploy CLI 用の Auth0 Management API 認証情報は CI の secret として注入する。設定ファイルには secret を保存しない。開発・本番などの環境ごとに Auth0 Tenant を分離し、同じ構成を環境別の値で適用する。
+Deploy CLI 用の Auth0 Management API 認証情報は CI の secret として注入する。設定ファイルには secret を保存しない。
 
 公式の Auth0 CLI は、Tenant の確認や個別リソースの操作に使用できる。Tenant 構成を宣言的に export/import する用途は Deploy CLI に統一する。
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,121 @@
+# 認証・認可設計
+
+## 決定事項
+
+| 主体 | 認証 | XLAIR 上の識別 |
+| --- | --- | --- |
+| 一般ユーザー | 筐体で読み取った card ID | `users.card` |
+| 筐体 | Auth0 M2M access token | Auth0 の client identity |
+| 管理者・運用者 | Auth0 user access token | Auth0 の user identity |
+
+- 一般ユーザーは Auth0 にアカウントを作成しない
+- card ID を XLAIR 上のユーザー識別子として扱う
+- カードの複製による同一ユーザーとしての利用を許容する
+- 筐体認証には Auth0 M2M を使用する
+- M2M Application は筐体ごとに作成する
+- 筐体 credentials に定期的な有効期限は設けない
+- 管理者・運用者の認証には Auth0 を使用する
+- OpenAPI では `userAuth` と `deviceAuth` を使用する
+- `/users/{userId}` は筐体と管理者の双方から更新できる
+- 更新メソッドは `PATCH` とする
+
+## Auth0 と XLAIR の責務
+
+Auth0 は認証と認証主体の大分類を担当する。XLAIR の endpoint、リソース、フィールド単位の認可は XLAIR 側で管理する。
+
+```text
+Auth0
+  └─ 認証、token 発行、管理者・筐体の識別
+
+XLAIR
+  └─ endpoint、リソース、操作内容に対する認可
+```
+
+`admin` と `device` は細かな API permission ではなく、XLAIR が認可ポリシーを選択するための principal の種類として扱う。
+
+Auth0 の role と permission を細かな権限体系として利用すると、`admin` や `device` が持つ XLAIR の操作内容まで Auth0 の設定に依存し、外部の認証基盤にアプリケーションの認可モデルを露出する。role と permission を利用する場合も、大分類とほぼ 1 対 1 の対応に留める。
+
+採用する Auth0 上の表現は次のとおりとする。
+
+```text
+admin role
+  └─ admin permission
+
+device M2M client grant
+  └─ device permission
+```
+
+Auth0 には endpoint やフィールド単位の permission を登録しない。API 層は token の `permissions` を XLAIR 内部の principal に変換し、domain 層と usecase 層には Auth0 固有の情報を渡さない。`scope` は OAuth の token 上の表現として扱い、アプリケーションの認可モデルには持ち込まない。custom claim は使用しない。
+
+```text
+DevicePrincipal { client_id }
+UserPrincipal { subject }
+```
+
+## 認証フロー
+
+### 一般ユーザー
+
+1. 筐体が card ID を読み取る
+2. 筐体が `deviceAuth` で API にアクセスする
+3. card ID を API の入力として送信する
+4. XLAIR が card ID からユーザーを解決する
+
+### 筐体
+
+筐体は筐体ごとの Auth0 M2M Application として API 用 access token を取得し、次の形式で送信する。
+
+```http
+Authorization: Bearer <device access token>
+```
+
+### 管理者・運用者
+
+Auth0 の user access token を `userAuth` として送信する。現時点では管理者・運用者用だが、将来の認証対象拡張を考慮して scheme 名は `userAuth` とする。
+
+各 endpoint の認証方式は [openapi.yaml](./openapi.yaml) に定義する。筐体と管理者の双方が利用する操作は、認証方式を OR で指定する。
+
+## 筐体 credentials の運用（推奨）
+
+筐体の登録時に provisioning 処理を実行し、筐体専用の Auth0 M2M Application を作成する。credential は secret manager から設置担当者または筐体へ安全に渡す。XLAIR の公開 API に credential 発行機能は設けない。
+
+client credential の定期的な失効は行わない。access token は短寿命に設定し、紛失・侵害時は Auth0 で対象 client を無効化するか、credential を rotation する。Auth0 で client を無効化しても発行済み token は有効期限まで有効なため、短寿命 token とする。
+
+credential の発行は、筐体の設置時に行う provisioning とする。公開 API からの自己登録は行わず、Auth0 Deploy CLI または Auth0 Management API を利用する管理用 provisioning 処理で M2M Application と API grant を作成する。
+
+Auth0 が利用するプランで Private Key JWT が利用できる場合は、筐体で生成した鍵ペアの公開鍵を Auth0 に登録し、秘密鍵を筐体外へ出さない方式を推奨する。利用できない場合は Client Secret を secure な provisioning 経路で筐体へ配布する。
+
+## Auth0 の構成管理
+
+Auth0 の構成管理には Auth0 Deploy CLI（`a0deploy`）を使用する。Tenant の設定をリポジトリで管理し、import 前に dry run で変更内容を確認する。
+
+管理対象:
+
+- XLAIR API の Resource Server
+- dashboard 用 Application
+- M2M Application
+- `admin` / `device` の role、permission、client grant
+- Tenant、Connection、Action の設定
+
+Deploy CLI 用の Auth0 Management API 認証情報は CI の secret として注入する。設定ファイルには secret を保存しない。開発・本番などの環境ごとに Auth0 Tenant を分離し、同じ構成を環境別の値で適用する。
+
+公式の Auth0 CLI は、Tenant の確認や個別リソースの操作に使用できる。Tenant 構成を宣言的に export/import する用途は Deploy CLI に統一する。
+
+## JWT 検証（推奨）
+
+Auth0 の OIDC discovery と JWKS を利用し、API サーバーで access token をローカル検証する。Auth0 の推奨設定に合わせ、次を検証する。
+
+- `iss`
+- `aud`
+- `exp`、`nbf`
+- `sub`
+- 許可する署名アルゴリズム（RS256）
+- JWKS の `kid`
+
+JWKS はキャッシュし、未知の `kid` を受け取った場合に鍵を再取得する。token の検証後、`permissions` と token の主体情報を XLAIR 内部の principal に変換する。
+
+## 未確定事項
+
+- XLAIR 側の endpoint・フィールド単位の認可ポリシー
+- JWT 検証に使用する Rust ライブラリ
+- 筐体 credential を Deploy CLI の構成管理と provisioning のどこまで一体化するか

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -45,12 +45,16 @@ device M2M client grant
   └─ device permission
 ```
 
-Auth0 には endpoint やフィールド単位の permission を登録しない。API 層は token の `permissions` を XLAIR 内部の principal に変換し、domain 層と usecase 層には Auth0 固有の情報を渡さない。`scope` は OAuth の token 上の表現として扱い、アプリケーションの認可モデルには持ち込まない。custom claim は使用しない。
+Auth0 には endpoint やフィールド単位の permission を登録しない。`admin` / `device` は操作権限の一覧ではなく、XLAIR が認可ポリシーを選択するための大分類である。role と permission を 1:1 に近づけることで、XLAIR の認可モデルを Auth0 の設定へ依存させない。
+
+API 層は token の `permissions` と token の主体種別を検証し、XLAIR 内部の principal に変換する。`scope` は OAuth の token 上の表現として扱い、アプリケーションの認可モデルには持ち込まない。custom claim は使用しない。
 
 ```text
 DevicePrincipal { client_id }
 UserPrincipal { subject }
 ```
+
+`device` permission を持つ client credentials token は `DevicePrincipal` に、`admin` permission を持つ user token は `UserPrincipal` の管理者主体に変換する。以降の endpoint・リソース・フィールド単位の認可は XLAIR 側で行う。
 
 ## 認証フロー
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -26,7 +26,7 @@ paths:
       summary: ユーザー登録
       description: カードIDで筐体に新規ログインした時に呼ぶ
       security:
-        - appApiKey: []
+        - deviceAuth: []
       requestBody:
         content:
           application/json:
@@ -42,7 +42,7 @@ paths:
         "400":
           description: Bad request - Invalid input data
         "401":
-          description: Unauthorized - Invalid API key
+          description: Unauthorized - Invalid device access token
         "409":
           description: Conflict - User with this card ID already exists
         "500":
@@ -54,7 +54,7 @@ paths:
       summary: カードIDからユーザー情報を取得
       description: カードIDで筐体に通常ログインした時に呼ぶ
       security:
-        - appApiKey: []
+        - deviceAuth: []
       parameters:
         - name: card
           in: query
@@ -72,19 +72,20 @@ paths:
         "400":
           description: Bad request - Missing or invalid card ID
         "401":
-          description: Unauthorized - Invalid API key
+          description: Unauthorized - Invalid device access token
         "404":
           description: Not found - User with specified card ID not found
         "500":
           description: Internal server error
   /users/{userId}:
-    post:
+    patch:
       tags:
         - station
       summary: ユーザー情報の更新
       description: ユーザーの表示名と公開設定を更新する
       security:
-        - appApiKey: []
+        - deviceAuth: []
+        - userAuth: []
       parameters:
         - name: userId
           in: path
@@ -105,7 +106,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/userData"
         "401":
-          description: Unauthorized - Invalid API key
+          description: Unauthorized - Invalid access token
+        "403":
+          description: Forbidden - The authenticated principal cannot update this user
         "404":
           description: Not found - User not found
         "500":
@@ -117,7 +120,7 @@ paths:
       summary: ユーザーのクレジット数を更新
       description: ユーザーのクレジット数を1増やす。ゲーム開始時に呼ぶ
       security:
-        - appApiKey: []
+        - deviceAuth: []
       parameters:
         - name: userId
           in: path
@@ -137,7 +140,7 @@ paths:
                     type: integer
                     description: 更新後のクレジット数
         "401":
-          description: Unauthorized - Invalid API key
+          description: Unauthorized - Invalid device access token
         "404":
           description: Not found - User not found
         "500":
@@ -149,7 +152,7 @@ paths:
       summary: ユーザーのプレイデータを取得
       description: ゲーム開始時にユーザーのプレイデータを一括取得する
       security:
-        - appApiKey: []
+        - deviceAuth: []
       parameters:
         - name: userId
           in: path
@@ -167,7 +170,7 @@ paths:
                 items:
                   $ref: "#/components/schemas/record"
         "401":
-          description: Unauthorized - Invalid API key
+          description: Unauthorized - Invalid device access token
         "404":
           description: Not found - User not found
         "500":
@@ -178,7 +181,7 @@ paths:
       summary: ユーザーのプレイデータを送信
       description: スコアの更新の有無に関わらず、ゲーム終了時にユーザーのプレイデータを送信する
       security:
-        - appApiKey: []
+        - deviceAuth: []
       parameters:
         - name: userId
           in: path
@@ -205,7 +208,7 @@ paths:
         "400":
           description: Bad request - Invalid input data
         "401":
-          description: Unauthorized - Invalid API key
+          description: Unauthorized - Invalid device access token
         "404":
           description: Not found - User or sheet not found
         "500":
@@ -217,7 +220,7 @@ paths:
       summary: ユーザーのプレイオプションを取得
       description: ゲーム開始時にユーザーのプレイオプションを取得する
       security:
-        - appApiKey: []
+        - deviceAuth: []
       parameters:
         - name: userId
           in: path
@@ -233,7 +236,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/userPlayOption"
         "401":
-          description: Unauthorized - Invalid API key
+          description: Unauthorized - Invalid device access token
         "404":
           description: Not found - User not found
         "500":
@@ -244,7 +247,7 @@ paths:
       summary: ユーザーのプレイオプションを更新
       description: ゲーム終了時にユーザーのプレイオプションを保存する
       security:
-        - appApiKey: []
+        - deviceAuth: []
       parameters:
         - name: userId
           in: path
@@ -265,7 +268,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/userPlayOption"
         "401":
-          description: Unauthorized - Invalid API key
+          description: Unauthorized - Invalid device access token
         "404":
           description: Not found - User not found
         "500":
@@ -277,7 +280,7 @@ paths:
       summary: 全曲・全譜面のメタデータを取得
       description: 同期用。筐体が起動した最初の一回しか実行しない
       security:
-        - appApiKey: []
+        - deviceAuth: []
       responses:
         "200":
           description: success
@@ -288,7 +291,7 @@ paths:
                 items:
                   $ref: "#/components/schemas/musicWithSheets"
         "401":
-          description: Unauthorized - Invalid API key
+          description: Unauthorized - Invalid device access token
         "500":
           description: Internal server error
   /rankings/sheets/{sheetId}:
@@ -367,7 +370,7 @@ paths:
       summary: システム全体の統計情報を取得
       description: 全ユーザーとレコードの集計値を参照する
       security:
-        - adminApiKey: []
+        - userAuth: []
       responses:
         "200":
           description: success
@@ -376,7 +379,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/globalStatistics"
         "401":
-          description: Unauthorized - Invalid admin API key
+          description: Unauthorized - Invalid administrator access token
+        "403":
+          description: Forbidden - Administrator permission is required
         "500":
           description: Internal server error
   /health:
@@ -400,17 +405,15 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
-      description: xlair.dev で利用する、基本的に read-only の認証トークン
-    appApiKey:
-      type: apiKey
-      name: XLAIR-API-Key
-      in: header
-      description: XLAIR の筐体が利用する API キー。userId とペアで利用する
-    adminApiKey:
-      type: apiKey
-      name: XLAIR-Admin-Key
-      in: header
-      description: 管理者用の API キー。デバッグ用。基本的には利用しない
+      description: |
+        Auth0 によるユーザー認証トークン。
+        現時点では管理者・運用者用 dashboard で利用する。
+        一般ユーザーは Auth0 アカウントを作成せず、筐体では card ID で識別する。
+    deviceAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: Auth0 Machine-to-Machine Application による筐体認証トークン
   schemas:
     userRegister:
       type: object

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -413,7 +413,9 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
-      description: Auth0 Machine-to-Machine Application による筐体認証トークン
+      description: |
+        Auth0 Machine-to-Machine Application による筐体認証トークン。
+        XLAIR が認証主体を筐体として分類するための大分類を含む。
   schemas:
     userRegister:
       type: object


### PR DESCRIPTION
## 概要

Auth0 Deploy CLI を利用した Tenant 構成管理と CI 自動適用の基盤を追加します。

## 変更内容

- Auth0 Deploy CLI 用の Tenant 構成を追加
- `admin` / `device` の粗い permission 方針を構成へ反映
- `main` への変更時に GitHub Actions から dry run 付きで自動適用
- Auth0 Management API の credentials を GitHub Actions secrets から注入
- 筐体共有の M2M Application と dashboard Application は callback URL 等の確定後に追加できるよう、構成管理の枠組みを整備
- Auth0 Deploy CLI の README を日本語化
- migration の runtime を Tokio に統一し、現在の CI で使用される Rust toolchain との互換性を修正
- 認証設計ドキュメントを共有 M2M Application 前提へ更新

## 確認方法

- `cargo build --workspace --all-targets --locked`
- `cargo test --workspace --all-targets --locked`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `auth0/tenant.yaml` の YAML 構文を確認
- `auth0/config.json` の JSON 構文を確認
- `git diff --check` を実行

## 前提

GitHub Actions secrets に `AUTH0_DOMAIN`、`AUTH0_CLIENT_ID`、`AUTH0_CLIENT_SECRET` を設定する必要があります。