### PR TITLE
Auth0 Application と client grant を追加

### DIFF
--- a/.github/workflows/auth0-deploy.yml
+++ b/.github/workflows/auth0-deploy.yml
@@ -26,7 +26,7 @@ jobs:
           node-version: 20
 
       - name: Install Auth0 Deploy CLI
-        run: npm install --global auth0-deploy-cli@8.41.0
+        run: npm install --global auth0-deploy-cli@8.42.0
 
       - name: Preview and apply Auth0 configuration
         run: |

--- a/auth0/README.md
+++ b/auth0/README.md
@@ -53,7 +53,7 @@ AUTH0_CLIENT_ID=<Deploy CLI 用 client ID>
 AUTH0_CLIENT_SECRET=<Deploy CLI 用 client secret>
 ```
 
-現時点の構成には Resource Server と Role が含まれるため、Management API には少なくとも次の権限が必要です。
+構成には Resource Server、Application、Role、client grant が含まれるため、Management API には少なくとも次の権限が必要です。
 
 ```text
 read:resource_servers
@@ -62,11 +62,21 @@ update:resource_servers
 read:roles
 create:roles
 update:roles
+
+read:clients
+create:clients
+update:clients
+
+read:client_grants
+create:client_grants
+update:client_grants
 ```
 
-Deploy CLI は client の存在確認にも `read:clients` を使用します。後続の構成で Application と client grant を管理する際は、`clients` と `client_grants` に対する read/create/update 権限を追加します。削除権限は付与しません。
+削除権限は付与しません。
 
-共有 M2M Application と dashboard 用 Regular Web Application は、Deploy CLI 用 Application の準備後に構成ファイルへ追加します。
+共有 M2M Application と dashboard 用 Regular Web Application は `tenant.yaml` で管理します。dashboard の callback URL、logout URL、web origin は dashboard の公開 URL が決まり次第設定します。
+
+初回の CI 実行で共有 M2M Application が作成されます。作成後に Auth0 で Client Secret を確認し、秘密情報として筐体へ配布します。Application を事前に手動作成する必要はありません。Client Secret の再発行時は全筐体へ新しい値を再配置します。
 
 ## 構成モデル
 
@@ -77,4 +87,4 @@ XLAIR API では、主体の大分類として次の permission を使用しま�
 
 `admin` role には `admin` permission を設定します。`device` permission は共有 M2M Application に client grant で付与します。endpoint やフィールド単位の認可は XLAIR 側で扱います。
 
-dashboard 用 Regular Web Application と共有 M2M Application は、次の構成作業で追加します。
+Deploy CLI 用 Application は構成管理の対象外です。共有 M2M Application と dashboard 用 Regular Web Application は `tenant.yaml` の構成対象です。

--- a/auth0/tenant.yaml
+++ b/auth0/tenant.yaml
@@ -14,6 +14,24 @@ resourceServers:
       - value: device
         description: Coarse-grained access class for device principals.
 
+clients:
+  - name: XLAIR Dashboard
+    app_type: regular_web
+    oidc_conformant: true
+    grant_types:
+      - authorization_code
+  - name: XLAIR Device
+    app_type: non_interactive
+    oidc_conformant: true
+    grant_types:
+      - client_credentials
+
+clientGrants:
+  - client_id: XLAIR Device
+    audience: https://api.xlair.dev
+    scope:
+      - device
+
 roles:
   - name: admin
     description: XLAIR administrator principal.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -85,9 +85,9 @@ Auth0 の user access token を `userAuth` として送信する。現時点で�
 
 client credential の定期的な失効は行わない。access token は短寿命に設定し、紛失・侵害時は Auth0 で対象 client を無効化するか、credential を rotation する。Auth0 で client を無効化しても発行済み token は有効期限まで有効なため、短寿命 token とする。
 
-credential の発行は、共有 M2M Application を初期構成する provisioning とする。公開 API からの自己登録は行わず、Auth0 Deploy CLI または Auth0 Management API を利用する管理用 provisioning 処理で M2M Application と API grant を作成する。
+credential の発行は、共有 M2M Application を初期構成する provisioning とする。初回の CI 実行で Application と API grant を作成し、生成された Client Secret を Auth0 から取得して筐体へ配布する。公開 API からの自己登録は行わない。
 
-Auth0 が利用するプランで Private Key JWT が利用できる場合は、筐体で生成した鍵ペアの公開鍵を Auth0 に登録し、秘密鍵を筐体外へ出さない方式を推奨する。利用できない場合は Client Secret を secure な provisioning 経路で筐体へ配布する。
+Client Secret を secure な provisioning 経路で筐体へ配布する。
 
 ## Auth0 の構成管理
 


### PR DESCRIPTION
## 概要

- dashboard 用 Regular Web Application を Auth0 Deploy CLI の管理対象に追加
- 共有筐体用 M2M Application と `device` client grant を追加
- 初回 CI 実行後の Client Secret 配布手順をドキュメント化
- Auth0 の coarse-grained な principal 分類と XLAIR 側の認可責務を明記

## 確認

- `auth0/tenant.yaml` の YAML 構文を確認
- `auth0/config.json` の JSON 構文を確認
- `git diff --check` を実行

## 補足

- dashboard の callback URL、logout URL、web origin は公開 URL 決定後に設定する
- Deploy CLI 用 M2M Application は手動作成が必要で、構成管理の対象外
- 共有筐体用 M2M Application は初回の CI 実行で作成される