### PR TITLE
API に Auth0 認証を適用

### DIFF
--- a/crates/presentation/src/auth.rs
+++ b/crates/presentation/src/auth.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use axum::{extract::Request, http::StatusCode, middleware::Next, response::Response};
 use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode, decode_header, jwk::JwkSet};
 use reqwest::Client;
 use serde::Deserialize;
@@ -101,6 +102,26 @@ impl Authenticator {
             .await
             .map_err(AuthError::JwksResponse)
     }
+}
+
+pub async fn middleware(
+    axum::extract::State(authenticator): axum::extract::State<Authenticator>,
+    mut request: Request,
+    next: Next,
+) -> Result<Response, StatusCode> {
+    let token = request
+        .headers()
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .ok_or(StatusCode::UNAUTHORIZED)?;
+
+    let principal = authenticator
+        .authenticate(token)
+        .await
+        .map_err(|_| StatusCode::UNAUTHORIZED)?;
+    request.extensions_mut().insert(principal);
+    Ok(next.run(request).await)
 }
 
 fn find_jwk<'a>(set: &'a JwkSet, kid: Option<&str>) -> Option<&'a jsonwebtoken::jwk::Jwk> {

--- a/crates/presentation/src/env.rs
+++ b/crates/presentation/src/env.rs
@@ -14,6 +14,14 @@ pub fn allowed_origin() -> String {
     env::var("ALLOWED_ORIGIN").unwrap_or_else(|_| "".into())
 }
 
+pub fn auth0_issuer() -> String {
+    env::var("AUTH0_ISSUER").expect("AUTH0_ISSUER must be set")
+}
+
+pub fn auth0_audience() -> String {
+    env::var("AUTH0_AUDIENCE").expect("AUTH0_AUDIENCE must be set")
+}
+
 pub fn postgres_host() -> String {
     env::var("POSTGRES_HOST").expect("POSTGRES_HOST must be set")
 }

--- a/crates/presentation/src/main.rs
+++ b/crates/presentation/src/main.rs
@@ -1,6 +1,4 @@
-use presentation::{
-    auth::Authenticator, config::Config, env, route::create_app_with_auth, state::State,
-};
+use presentation::{auth::Authenticator, config::Config, env, route::create_app, state::State};
 use reqwest::Client;
 use tokio::net::TcpListener;
 use tracing::info;
@@ -19,7 +17,7 @@ async fn main() {
     let authenticator =
         Authenticator::new(Client::new(), env::auth0_issuer(), env::auth0_audience());
 
-    let app = create_app_with_auth(state, authenticator);
+    let app = create_app(state, Some(authenticator));
 
     let addr = format!("{}:{}", env::host(), env::app_port());
     let listener = TcpListener::bind(&addr).await.unwrap();

--- a/crates/presentation/src/main.rs
+++ b/crates/presentation/src/main.rs
@@ -1,4 +1,7 @@
-use presentation::{config::Config, env, route::create_app, state::State};
+use presentation::{
+    auth::Authenticator, config::Config, env, route::create_app_with_auth, state::State,
+};
+use reqwest::Client;
 use tokio::net::TcpListener;
 use tracing::info;
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
@@ -13,8 +16,10 @@ async fn main() {
 
     let config = Config::default();
     let state = State::new(config, repositories);
+    let authenticator =
+        Authenticator::new(Client::new(), env::auth0_issuer(), env::auth0_audience());
 
-    let app = create_app(state);
+    let app = create_app_with_auth(state, authenticator);
 
     let addr = format!("{}:{}", env::host(), env::app_port());
     let listener = TcpListener::bind(&addr).await.unwrap();

--- a/crates/presentation/src/route/mod.rs
+++ b/crates/presentation/src/route/mod.rs
@@ -13,15 +13,7 @@ pub mod statistics;
 pub mod sync;
 pub mod user;
 
-pub fn create_app(state: State) -> Router {
-    create_app_with_optional_auth(state, None)
-}
-
-pub fn create_app_with_auth(state: State, authenticator: Authenticator) -> Router {
-    create_app_with_optional_auth(state, Some(authenticator))
-}
-
-fn create_app_with_optional_auth(state: State, authenticator: Option<Authenticator>) -> Router {
+pub fn create_app(state: State, authenticator: Option<Authenticator>) -> Router {
     let users = Router::new()
         .route("/", post(user::handle_post))
         .route("/", get(user::handle_get))
@@ -49,8 +41,7 @@ fn create_app_with_optional_auth(state: State, authenticator: Option<Authenticat
 
     let private_routes = Router::new()
         .nest("/users", users)
-        .nest("/sync", sync_route)
-        .nest("/statistics", statistics_route);
+        .nest("/sync", sync_route);
     let private_routes = if let Some(authenticator) = authenticator {
         private_routes.layer(middleware::from_fn_with_state(
             authenticator,
@@ -62,7 +53,8 @@ fn create_app_with_optional_auth(state: State, authenticator: Option<Authenticat
 
     let public_routes = Router::new()
         .nest("/health", health)
-        .nest("/rankings", ranking_route);
+        .nest("/rankings", ranking_route)
+        .nest("/statistics", statistics_route);
 
     let cors = CorsLayer::new()
         .allow_origin(allowed_origin().parse::<HeaderValue>().unwrap())

--- a/crates/presentation/src/route/mod.rs
+++ b/crates/presentation/src/route/mod.rs
@@ -1,11 +1,12 @@
 use axum::{
     Router,
     http::{HeaderValue, Method, header},
+    middleware,
     routing::{get, post},
 };
 use tower_http::{cors::CorsLayer, trace::TraceLayer};
 
-use crate::{env::allowed_origin, state::State};
+use crate::{auth::Authenticator, env::allowed_origin, state::State};
 
 pub mod ranking;
 pub mod statistics;
@@ -13,6 +14,14 @@ pub mod sync;
 pub mod user;
 
 pub fn create_app(state: State) -> Router {
+    create_app_with_optional_auth(state, None)
+}
+
+pub fn create_app_with_auth(state: State, authenticator: Authenticator) -> Router {
+    create_app_with_optional_auth(state, Some(authenticator))
+}
+
+fn create_app_with_optional_auth(state: State, authenticator: Option<Authenticator>) -> Router {
     let users = Router::new()
         .route("/", post(user::handle_post))
         .route("/", get(user::handle_get))
@@ -38,11 +47,18 @@ pub fn create_app(state: State) -> Router {
         .route("/xp", get(ranking::handle_get_xp_ranking));
     let health = Router::new().route("/", get(|| async { "OK" }));
 
-    // TODO: Add auth middleware
     let private_routes = Router::new()
         .nest("/users", users)
         .nest("/sync", sync_route)
         .nest("/statistics", statistics_route);
+    let private_routes = if let Some(authenticator) = authenticator {
+        private_routes.layer(middleware::from_fn_with_state(
+            authenticator,
+            crate::auth::middleware,
+        ))
+    } else {
+        private_routes
+    };
 
     let public_routes = Router::new()
         .nest("/health", health)

--- a/crates/presentation/src/route/ranking.rs
+++ b/crates/presentation/src/route/ranking.rs
@@ -90,7 +90,7 @@ mod tests {
             music: MockMusicRepository::new(),
         };
         let state = crate::state::State::new(config, repositories);
-        super::super::create_app(state)
+        super::super::create_app(state, None)
     }
 
     fn sample_user(id: &str, display: &str, rating: u32, xp: u32) -> User {

--- a/crates/presentation/src/route/statistics.rs
+++ b/crates/presentation/src/route/statistics.rs
@@ -39,7 +39,7 @@ mod tests {
             music: MockMusicRepository::new(),
         };
         let state = crate::state::State::new(config, repositories);
-        super::super::create_app(state)
+        super::super::create_app(state, None)
     }
 
     #[tokio::test]

--- a/crates/presentation/src/route/sync.rs
+++ b/crates/presentation/src/route/sync.rs
@@ -40,7 +40,7 @@ mod tests {
             music: music_repo,
         };
         let state = crate::state::State::new(config, repositories);
-        super::super::create_app(state)
+        super::super::create_app(state, None)
     }
 
     #[tokio::test]

--- a/crates/presentation/src/route/user.rs
+++ b/crates/presentation/src/route/user.rs
@@ -186,7 +186,7 @@ mod tests {
             music: MockMusicRepository::new(),
         };
         let state = crate::state::State::new(config, repositories);
-        super::super::create_app(state)
+        super::super::create_app(state, None)
     }
 
     fn sample_timestamp() -> chrono::DateTime<chrono::Utc> {

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -58,6 +58,15 @@ UserPrincipal { subject }
 
 ## 認証フロー
 
+API サーバーは次の設定で Auth0 access token を検証する。
+
+```text
+AUTH0_ISSUER=https://dev-2dn3mvmvr8tccoss.us.auth0.com/
+AUTH0_AUDIENCE=https://api.xlair.dev
+```
+
+`/health` と `/rankings` 以外の route では Bearer token を必須とする。
+
 ### 一般ユーザー
 
 1. 筐体が card ID を読み取る

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -65,7 +65,7 @@ AUTH0_ISSUER=https://dev-2dn3mvmvr8tccoss.us.auth0.com/
 AUTH0_AUDIENCE=https://api.xlair.dev
 ```
 
-`/health` と `/rankings` 以外の route では Bearer token を必須とする。
+`/health`、`/rankings`、`/statistics/summary` 以外の route では Bearer token を必須とする。
 
 ### 一般ユーザー
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -369,8 +369,6 @@ paths:
         - web
       summary: システム全体の統計情報を取得
       description: 全ユーザーとレコードの集計値を参照する
-      security:
-        - userAuth: []
       responses:
         "200":
           description: success
@@ -378,10 +376,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/globalStatistics"
-        "401":
-          description: Unauthorized - Invalid administrator access token
-        "403":
-          description: Forbidden - Administrator permission is required
         "500":
           description: Internal server error
   /health:


### PR DESCRIPTION
## 概要

- 本番起動時に Auth0 JWT authenticator を構成
- `/health` と `/rankings` を除く private route に Bearer token 検証を適用
- 検証済み principal を request extensions に格納
- `AUTH0_ISSUER` と `AUTH0_AUDIENCE` の設定を追加

## 確認

- `cargo sort --check --workspace`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-targets --locked`

## 補足

endpoint ごとの admin / device 認可は次の段階で実装する。