### PR TITLE
endpoint 単位の認可を追加

### DIFF
--- a/crates/presentation/src/auth.rs
+++ b/crates/presentation/src/auth.rs
@@ -124,6 +124,14 @@ pub async fn middleware(
     Ok(next.run(request).await)
 }
 
+pub async fn require_device(request: Request, next: Next) -> Result<Response, StatusCode> {
+    match request.extensions().get::<Principal>() {
+        Some(Principal::Device { .. }) => Ok(next.run(request).await),
+        Some(Principal::Admin { .. }) => Err(StatusCode::FORBIDDEN),
+        None => Err(StatusCode::UNAUTHORIZED),
+    }
+}
+
 fn find_jwk<'a>(set: &'a JwkSet, kid: Option<&str>) -> Option<&'a jsonwebtoken::jwk::Jwk> {
     set.keys
         .iter()

--- a/crates/presentation/src/auth.rs
+++ b/crates/presentation/src/auth.rs
@@ -14,10 +14,18 @@ pub enum PrincipalKind {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Principal {
-    pub kind: PrincipalKind,
-    pub subject: String,
-    pub client_id: Option<String>,
+pub enum Principal {
+    Admin { subject: String },
+    Device { client_id: String },
+}
+
+impl Principal {
+    pub fn kind(&self) -> PrincipalKind {
+        match self {
+            Self::Admin { .. } => PrincipalKind::Admin,
+            Self::Device { .. } => PrincipalKind::Device,
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -40,7 +48,7 @@ impl AuthorizationPolicy {
     }
 
     pub fn allows(&self, principal: &Principal) -> bool {
-        self.allowed_kinds.contains(&principal.kind)
+        self.allowed_kinds.contains(&principal.kind())
     }
 }
 
@@ -184,11 +192,7 @@ fn principal_from_claims(claims: Claims) -> Result<Principal, AuthError> {
             .azp
             .or_else(|| claims.sub.strip_suffix("@clients").map(ToOwned::to_owned))
             .ok_or(AuthError::InvalidToken)?;
-        return Ok(Principal {
-            kind: PrincipalKind::Device,
-            subject: claims.sub,
-            client_id: Some(client_id),
-        });
+        return Ok(Principal::Device { client_id });
     }
 
     if claims
@@ -196,10 +200,8 @@ fn principal_from_claims(claims: Claims) -> Result<Principal, AuthError> {
         .iter()
         .any(|permission| permission == "admin")
     {
-        return Ok(Principal {
-            kind: PrincipalKind::Admin,
+        return Ok(Principal::Admin {
             subject: claims.sub,
-            client_id: None,
         });
     }
 
@@ -221,10 +223,8 @@ mod tests {
 
         assert_eq!(
             principal,
-            Principal {
-                kind: PrincipalKind::Device,
-                subject: "client-id@clients".into(),
-                client_id: Some("client-id".into())
+            Principal::Device {
+                client_id: "client-id".into()
             }
         );
     }
@@ -240,10 +240,8 @@ mod tests {
 
         assert_eq!(
             principal,
-            Principal {
-                kind: PrincipalKind::Admin,
-                subject: "auth0|user-id".into(),
-                client_id: None
+            Principal::Admin {
+                subject: "auth0|user-id".into()
             }
         );
     }
@@ -263,10 +261,8 @@ mod tests {
     fn policy_can_allow_multiple_principal_kinds() {
         let policy =
             super::AuthorizationPolicy::any_of([PrincipalKind::Admin, PrincipalKind::Device]);
-        let principal = Principal {
-            kind: PrincipalKind::Admin,
+        let principal = Principal::Admin {
             subject: "auth0|user-id".into(),
-            client_id: None,
         };
 
         assert!(policy.allows(&principal));

--- a/crates/presentation/src/auth.rs
+++ b/crates/presentation/src/auth.rs
@@ -7,10 +7,41 @@ use serde::Deserialize;
 use thiserror::Error;
 use tokio::sync::RwLock;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PrincipalKind {
+    Admin,
+    Device,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum Principal {
-    Admin { subject: String },
-    Device { client_id: String },
+pub struct Principal {
+    pub kind: PrincipalKind,
+    pub subject: String,
+    pub client_id: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct AuthorizationPolicy {
+    allowed_kinds: Vec<PrincipalKind>,
+}
+
+impl AuthorizationPolicy {
+    pub fn only(kind: PrincipalKind) -> Self {
+        Self::any_of([kind])
+    }
+
+    pub fn any_of<I>(kinds: I) -> Self
+    where
+        I: IntoIterator<Item = PrincipalKind>,
+    {
+        Self {
+            allowed_kinds: kinds.into_iter().collect(),
+        }
+    }
+
+    pub fn allows(&self, principal: &Principal) -> bool {
+        self.allowed_kinds.contains(&principal.kind)
+    }
 }
 
 #[derive(Clone)]
@@ -124,10 +155,14 @@ pub async fn middleware(
     Ok(next.run(request).await)
 }
 
-pub async fn require_device(request: Request, next: Next) -> Result<Response, StatusCode> {
+pub async fn authorize(
+    axum::extract::State(policy): axum::extract::State<AuthorizationPolicy>,
+    request: Request,
+    next: Next,
+) -> Result<Response, StatusCode> {
     match request.extensions().get::<Principal>() {
-        Some(Principal::Device { .. }) => Ok(next.run(request).await),
-        Some(Principal::Admin { .. }) => Err(StatusCode::FORBIDDEN),
+        Some(principal) if policy.allows(principal) => Ok(next.run(request).await),
+        Some(_) => Err(StatusCode::FORBIDDEN),
         None => Err(StatusCode::UNAUTHORIZED),
     }
 }
@@ -149,7 +184,11 @@ fn principal_from_claims(claims: Claims) -> Result<Principal, AuthError> {
             .azp
             .or_else(|| claims.sub.strip_suffix("@clients").map(ToOwned::to_owned))
             .ok_or(AuthError::InvalidToken)?;
-        return Ok(Principal::Device { client_id });
+        return Ok(Principal {
+            kind: PrincipalKind::Device,
+            subject: claims.sub,
+            client_id: Some(client_id),
+        });
     }
 
     if claims
@@ -157,8 +196,10 @@ fn principal_from_claims(claims: Claims) -> Result<Principal, AuthError> {
         .iter()
         .any(|permission| permission == "admin")
     {
-        return Ok(Principal::Admin {
+        return Ok(Principal {
+            kind: PrincipalKind::Admin,
             subject: claims.sub,
+            client_id: None,
         });
     }
 
@@ -167,7 +208,7 @@ fn principal_from_claims(claims: Claims) -> Result<Principal, AuthError> {
 
 #[cfg(test)]
 mod tests {
-    use super::{Claims, Principal, principal_from_claims};
+    use super::{Claims, Principal, PrincipalKind, principal_from_claims};
 
     #[test]
     fn converts_device_claims_to_device_principal() {
@@ -180,8 +221,10 @@ mod tests {
 
         assert_eq!(
             principal,
-            Principal::Device {
-                client_id: "client-id".into()
+            Principal {
+                kind: PrincipalKind::Device,
+                subject: "client-id@clients".into(),
+                client_id: Some("client-id".into())
             }
         );
     }
@@ -197,8 +240,10 @@ mod tests {
 
         assert_eq!(
             principal,
-            Principal::Admin {
-                subject: "auth0|user-id".into()
+            Principal {
+                kind: PrincipalKind::Admin,
+                subject: "auth0|user-id".into(),
+                client_id: None
             }
         );
     }
@@ -212,5 +257,18 @@ mod tests {
         });
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn policy_can_allow_multiple_principal_kinds() {
+        let policy =
+            super::AuthorizationPolicy::any_of([PrincipalKind::Admin, PrincipalKind::Device]);
+        let principal = Principal {
+            kind: PrincipalKind::Admin,
+            subject: "auth0|user-id".into(),
+            client_id: None,
+        };
+
+        assert!(policy.allows(&principal));
     }
 }

--- a/crates/presentation/src/route/mod.rs
+++ b/crates/presentation/src/route/mod.rs
@@ -2,7 +2,7 @@ use axum::{
     Router,
     http::{HeaderValue, Method, header},
     middleware,
-    routing::{get, post},
+    routing::{get, patch, post},
 };
 use tower_http::{cors::CorsLayer, trace::TraceLayer};
 
@@ -17,6 +17,7 @@ pub fn create_app(state: State, authenticator: Option<Authenticator>) -> Router 
     let device_users = Router::new()
         .route("/", post(user::handle_post))
         .route("/", get(user::handle_get))
+        .route("/{userId}", patch(user::handle_update_user))
         .route(
             "/{userId}/records",
             get(user::handle_get_records).post(user::handle_post_records),
@@ -29,7 +30,6 @@ pub fn create_app(state: State, authenticator: Option<Authenticator>) -> Router 
             "/{userId}/credits/increment",
             post(user::handle_increment_credits),
         );
-    let user_update = Router::new().route("/{userId}", post(user::handle_update_user));
     let sync_route = Router::new().route("/", get(sync::handle_get));
     let statistics_route = Router::new().route("/summary", get(statistics::handle_get_summary));
     let ranking_route = Router::new()
@@ -43,23 +43,14 @@ pub fn create_app(state: State, authenticator: Option<Authenticator>) -> Router 
         .nest("/users", device_users)
         .nest("/sync", sync_route);
     let private_routes = if let Some(authenticator) = authenticator {
-        let user_update = user_update.layer(middleware::from_fn_with_state(
-            authenticator.clone(),
-            crate::auth::middleware,
-        ));
-        let device_routes = device_routes
+        device_routes
             .layer(middleware::from_fn(crate::auth::require_device))
             .layer(middleware::from_fn_with_state(
                 authenticator,
                 crate::auth::middleware,
-            ));
-        Router::new()
-            .merge(device_routes)
-            .nest("/users", user_update)
+            ))
     } else {
-        Router::new()
-            .merge(device_routes)
-            .nest("/users", user_update)
+        device_routes
     };
 
     let public_routes = Router::new()

--- a/crates/presentation/src/route/mod.rs
+++ b/crates/presentation/src/route/mod.rs
@@ -6,7 +6,11 @@ use axum::{
 };
 use tower_http::{cors::CorsLayer, trace::TraceLayer};
 
-use crate::{auth::Authenticator, env::allowed_origin, state::State};
+use crate::{
+    auth::{Authenticator, AuthorizationPolicy, PrincipalKind},
+    env::allowed_origin,
+    state::State,
+};
 
 pub mod ranking;
 pub mod statistics;
@@ -39,18 +43,21 @@ pub fn create_app(state: State, authenticator: Option<Authenticator>) -> Router 
         .route("/xp", get(ranking::handle_get_xp_ranking));
     let health = Router::new().route("/", get(|| async { "OK" }));
 
-    let device_routes = Router::new()
+    let protected_routes = Router::new()
         .nest("/users", device_users)
         .nest("/sync", sync_route);
     let private_routes = if let Some(authenticator) = authenticator {
-        device_routes
-            .layer(middleware::from_fn(crate::auth::require_device))
+        protected_routes
+            .layer(middleware::from_fn_with_state(
+                AuthorizationPolicy::only(PrincipalKind::Device),
+                crate::auth::authorize,
+            ))
             .layer(middleware::from_fn_with_state(
                 authenticator,
                 crate::auth::middleware,
             ))
     } else {
-        device_routes
+        protected_routes
     };
 
     let public_routes = Router::new()

--- a/crates/presentation/src/route/mod.rs
+++ b/crates/presentation/src/route/mod.rs
@@ -18,7 +18,7 @@ pub mod sync;
 pub mod user;
 
 pub fn create_app(state: State, authenticator: Option<Authenticator>) -> Router {
-    let device_users = Router::new()
+    let users = Router::new()
         .route("/", post(user::handle_post))
         .route("/", get(user::handle_get))
         .route("/{userId}", patch(user::handle_update_user))
@@ -44,7 +44,7 @@ pub fn create_app(state: State, authenticator: Option<Authenticator>) -> Router 
     let health = Router::new().route("/", get(|| async { "OK" }));
 
     let private_routes = Router::new()
-        .nest("/users", device_users)
+        .nest("/users", users)
         .nest("/sync", sync_route);
     let private_routes = if let Some(authenticator) = authenticator {
         private_routes

--- a/crates/presentation/src/route/mod.rs
+++ b/crates/presentation/src/route/mod.rs
@@ -14,10 +14,9 @@ pub mod sync;
 pub mod user;
 
 pub fn create_app(state: State, authenticator: Option<Authenticator>) -> Router {
-    let users = Router::new()
+    let device_users = Router::new()
         .route("/", post(user::handle_post))
         .route("/", get(user::handle_get))
-        .route("/{userId}", post(user::handle_update_user))
         .route(
             "/{userId}/records",
             get(user::handle_get_records).post(user::handle_post_records),
@@ -30,6 +29,7 @@ pub fn create_app(state: State, authenticator: Option<Authenticator>) -> Router 
             "/{userId}/credits/increment",
             post(user::handle_increment_credits),
         );
+    let user_update = Router::new().route("/{userId}", post(user::handle_update_user));
     let sync_route = Router::new().route("/", get(sync::handle_get));
     let statistics_route = Router::new().route("/summary", get(statistics::handle_get_summary));
     let ranking_route = Router::new()
@@ -39,16 +39,27 @@ pub fn create_app(state: State, authenticator: Option<Authenticator>) -> Router 
         .route("/xp", get(ranking::handle_get_xp_ranking));
     let health = Router::new().route("/", get(|| async { "OK" }));
 
-    let private_routes = Router::new()
-        .nest("/users", users)
+    let device_routes = Router::new()
+        .nest("/users", device_users)
         .nest("/sync", sync_route);
     let private_routes = if let Some(authenticator) = authenticator {
-        private_routes.layer(middleware::from_fn_with_state(
-            authenticator,
+        let user_update = user_update.layer(middleware::from_fn_with_state(
+            authenticator.clone(),
             crate::auth::middleware,
-        ))
+        ));
+        let device_routes = device_routes
+            .layer(middleware::from_fn(crate::auth::require_device))
+            .layer(middleware::from_fn_with_state(
+                authenticator,
+                crate::auth::middleware,
+            ));
+        Router::new()
+            .merge(device_routes)
+            .nest("/users", user_update)
     } else {
-        private_routes
+        Router::new()
+            .merge(device_routes)
+            .nest("/users", user_update)
     };
 
     let public_routes = Router::new()

--- a/crates/presentation/src/route/mod.rs
+++ b/crates/presentation/src/route/mod.rs
@@ -43,11 +43,11 @@ pub fn create_app(state: State, authenticator: Option<Authenticator>) -> Router 
         .route("/xp", get(ranking::handle_get_xp_ranking));
     let health = Router::new().route("/", get(|| async { "OK" }));
 
-    let protected_routes = Router::new()
+    let private_routes = Router::new()
         .nest("/users", device_users)
         .nest("/sync", sync_route);
     let private_routes = if let Some(authenticator) = authenticator {
-        protected_routes
+        private_routes
             .layer(middleware::from_fn_with_state(
                 AuthorizationPolicy::only(PrincipalKind::Device),
                 crate::auth::authorize,
@@ -57,7 +57,7 @@ pub fn create_app(state: State, authenticator: Option<Authenticator>) -> Router 
                 crate::auth::middleware,
             ))
     } else {
-        protected_routes
+        private_routes
     };
 
     let public_routes = Router::new()

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -56,7 +56,7 @@ UserPrincipal { subject }
 
 `device` permission を持つ client credentials token は `DevicePrincipal` に、`admin` permission を持つ user token は `UserPrincipal` の管理者主体に変換する。以降の endpoint・リソース・フィールド単位の認可は XLAIR 側で行う。
 
-現在の endpoint 認可では、筐体向けの users / sync route に `device`、ユーザー更新に `device` または `admin` を要求する。`/health`、`/rankings`、`/statistics/summary` は公開する。
+現在の endpoint 認可では、private route に `device` を要求する。`/health`、`/rankings`、`/statistics/summary` は公開する。`admin` principal の endpoint 利用は今後追加する。
 
 ## 認証フロー
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -56,6 +56,8 @@ UserPrincipal { subject }
 
 `device` permission を持つ client credentials token は `DevicePrincipal` に、`admin` permission を持つ user token は `UserPrincipal` の管理者主体に変換する。以降の endpoint・リソース・フィールド単位の認可は XLAIR 側で行う。
 
+現在の endpoint 認可では、筐体向けの users / sync route に `device`、ユーザー更新に `device` または `admin` を要求する。`/health`、`/rankings`、`/statistics/summary` は公開する。
+
 ## 認証フロー
 
 API サーバーは次の設定で Auth0 access token を検証する。

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -85,7 +85,6 @@ paths:
       description: ユーザーの表示名と公開設定を更新する
       security:
         - deviceAuth: []
-        - userAuth: []
       parameters:
         - name: userId
           in: path


### PR DESCRIPTION
## 概要

- `device` principal 専用の users / sync route 認可を追加
- ユーザー更新 route は `device` / `admin` の双方を許可
- `admin` principal に筐体向け操作を許可しない
- endpoint 認可の現在の公開範囲をドキュメントへ反映

## 確認

- `cargo sort --check --workspace`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-targets --locked`

## 補足

`/health`、`/rankings`、`/statistics/summary` は引き続き公開する。