### PR TITLE
認証の利用手順を追加

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,5 +1,7 @@
 # 認証・認可設計
 
+利用手順は [筐体の認証](./device-authentication.md) と [管理 dashboard の認証](./dashboard-authentication.md) を参照する。
+
 ## 決定事項
 
 | 主体 | 認証 | XLAIR 上の識別 |

--- a/docs/dashboard-authentication.md
+++ b/docs/dashboard-authentication.md
@@ -1,0 +1,29 @@
+# 管理 dashboard の認証
+
+管理 dashboard は Auth0 の `XLAIR Dashboard` Regular Web Application を使用する。一般ユーザー向けの Auth0 アカウントは作成しない。
+
+## Auth0 Application の設定
+
+dashboard の公開 URL が決まったら、Auth0 の Application に次を設定する。
+
+- Allowed Callback URLs: dashboard の callback URL
+- Allowed Logout URLs: dashboard の logout URL
+- Allowed Web Origins: dashboard の origin
+
+Application は `auth0/tenant.yaml` で管理する。URL は公開 URL 決定後に構成へ追加する。
+
+## API の呼び出し
+
+ログイン後に取得した Auth0 access token を、API 呼び出しの Bearer token として送信する。
+
+```http
+Authorization: Bearer <user access token>
+```
+
+access token を要求する際は API の audience を指定する。
+
+```text
+https://api.xlair.dev
+```
+
+現時点では API の private endpoint は `device` principal 用であり、dashboard 用の `userAuth` endpoint は未提供である。管理者向け endpoint を追加する際に `userAuth` を使用する。

--- a/docs/dashboard-authentication.md
+++ b/docs/dashboard-authentication.md
@@ -1,6 +1,6 @@
 # 管理 dashboard の認証
 
-管理 dashboard は Auth0 の `XLAIR Dashboard` Regular Web Application を使用する。一般ユーザー向けの Auth0 アカウントは作成しない。
+管理 dashboard は Auth0 の `XLAIR Dashboard` Regular Web Application を使用する。
 
 ## Auth0 Application の設定
 
@@ -25,5 +25,3 @@ access token を要求する際は API の audience を指定する。
 ```text
 https://api.xlair.dev
 ```
-
-現時点では API の private endpoint は `device` principal 用であり、dashboard 用の `userAuth` endpoint は未提供である。管理者向け endpoint を追加する際に `userAuth` を使用する。

--- a/docs/device-authentication.md
+++ b/docs/device-authentication.md
@@ -1,0 +1,46 @@
+# 筐体の認証
+
+筐体は Auth0 の共有 M2M Application で access token を取得し、XLAIR API に送信する。
+
+## 設定
+
+筐体の `.env` に次を設定する。
+
+```text
+AUTH0_DOMAIN=dev-2dn3mvmvr8tccoss.us.auth0.com
+AUTH0_CLIENT_ID=<共有 M2M Application の Client ID>
+AUTH0_CLIENT_SECRET=<共有 M2M Application の Client Secret>
+AUTH0_AUDIENCE=https://api.xlair.dev
+```
+
+Client Secret は provisioning 時に設置し、リポジトリやログへ保存しない。
+
+## token の取得
+
+Auth0 の token endpoint に Client Credentials Grant を要求する。
+
+```sh
+curl --request POST \
+  --url https://dev-2dn3mvmvr8tccoss.us.auth0.com/oauth/token \
+  --header 'content-type: application/json' \
+  --data '{
+    "client_id": "<共有 M2M Application の Client ID>",
+    "client_secret": "<共有 M2M Application の Client Secret>",
+    "audience": "https://api.xlair.dev",
+    "grant_type": "client_credentials"
+  }'
+```
+
+レスポンスの `access_token` を API 呼び出しに使用する。token の有効期限が切れた場合は再取得する。
+
+## API の呼び出し
+
+```http
+Authorization: Bearer <device access token>
+```
+
+筐体は `deviceAuth` が定義された endpoint を利用できる。一般ユーザーは Auth0 に登録せず、card ID を API の入力として送信する。
+
+## Secret の更新
+
+漏洩が疑われる場合は Auth0 で Client Secret を再発行し、全筐体へ新しい Secret を再配置する。再配置が完了するまで旧 Secret を失効させるタイミングは運用担当者が判断する。

--- a/docs/device-authentication.md
+++ b/docs/device-authentication.md
@@ -1,6 +1,6 @@
 # 筐体の認証
 
-筐体は Auth0 の共有 M2M Application で access token を取得し、XLAIR API に送信する。
+筐体は Auth0 の M2M Application で access token を取得し、XLAIR API に送信する。
 
 ## 設定
 
@@ -8,8 +8,8 @@
 
 ```text
 AUTH0_DOMAIN=dev-2dn3mvmvr8tccoss.us.auth0.com
-AUTH0_CLIENT_ID=<共有 M2M Application の Client ID>
-AUTH0_CLIENT_SECRET=<共有 M2M Application の Client Secret>
+AUTH0_CLIENT_ID=<M2M Application の Client ID>
+AUTH0_CLIENT_SECRET=<M2M Application の Client Secret>
 AUTH0_AUDIENCE=https://api.xlair.dev
 ```
 
@@ -24,8 +24,8 @@ curl --request POST \
   --url https://dev-2dn3mvmvr8tccoss.us.auth0.com/oauth/token \
   --header 'content-type: application/json' \
   --data '{
-    "client_id": "<共有 M2M Application の Client ID>",
-    "client_secret": "<共有 M2M Application の Client Secret>",
+    "client_id": "<M2M Application の Client ID>",
+    "client_secret": "<M2M Application の Client Secret>",
     "audience": "https://api.xlair.dev",
     "grant_type": "client_credentials"
   }'
@@ -39,7 +39,7 @@ curl --request POST \
 Authorization: Bearer <device access token>
 ```
 
-筐体は `deviceAuth` が定義された endpoint を利用できる。一般ユーザーは Auth0 に登録せず、card ID を API の入力として送信する。
+筐体は `deviceAuth` が定義された endpoint を利用できる。
 
 ## Secret の更新
 


### PR DESCRIPTION
## 概要

- 筐体向け Auth0 M2M 認証の設定・token 取得・API 利用手順を追加
- 管理 dashboard 向け Auth0 Regular Web Application の設定・API 利用手順を追加
- 設計ドキュメントから利用手順へのリンクを追加

## 確認

- `git diff --check`

機密情報はドキュメントへ記載していない。