### PR TITLE
複数レコードの取得順と JSON casing を修正

### DIFF
--- a/crates/infrastructure/src/record/read.rs
+++ b/crates/infrastructure/src/record/read.rs
@@ -84,6 +84,8 @@ pub async fn records_by_user_and_sheet_ids(
     let models = Records::find()
         .filter(entities::records::Column::UserId.eq(uuid))
         .filter(entities::records::Column::SheetId.is_in(sheet_uuids))
+        .order_by_asc(entities::records::Column::UpdatedAt)
+        .order_by_asc(entities::records::Column::Id)
         .all(db)
         .await
         .map_err(|err| {

--- a/crates/presentation/src/model/sync.rs
+++ b/crates/presentation/src/model/sync.rs
@@ -3,6 +3,7 @@ use serde::Serialize;
 use usecase::model::music::{MusicDto, MusicWithSheetsDto, SheetDto};
 
 #[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SyncItemResponse {
     pub music: MusicResponse,
     pub sheets: Vec<SheetResponse>,

--- a/crates/presentation/src/model/user.rs
+++ b/crates/presentation/src/model/user.rs
@@ -92,6 +92,7 @@ impl From<UserDataDto> for UserDataResponse {
 }
 
 #[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CreditsIncrementResponse {
     pub credits: u32,
 }


### PR DESCRIPTION
## 概要
- sheet ID 指定のレコード取得に updated_at と id の order by を追加
- SyncItemResponse と CreditsIncrementResponse を camelCase serialization に統一

## 確認
- cargo fmt --all -- --check
- cargo test --workspace --all-targets