### PR TITLE
DB接続失敗をエラーとして返す

### DIFF
--- a/crates/infrastructure/src/lib.rs
+++ b/crates/infrastructure/src/lib.rs
@@ -29,19 +29,13 @@ impl RepositoriesImpl {
     }
 
     /// Initializes the SeaORM connection. Implicitly depends on a tracing subscriber already being set up so logging can emit.
-    ///
-    /// # Panics
-    /// Panics if database connection fails. This is appropriate for startup as the application
-    /// cannot function without a database connection.
     #[instrument(name = "infrastructure.repositories.new_default", skip(db_url))]
-    pub async fn new_default(db_url: &str) -> Self {
+    pub async fn new_default(db_url: &str) -> Result<Self, sea_orm::DbErr> {
         info!("Connecting to database via SeaORM");
-        let db = sea_orm::Database::connect(db_url)
-            .await
-            .unwrap_or_else(|err| {
-                error!(error = %err, "Failed to connect to the database");
-                panic!("Failed to connect to the database");
-            });
+        let db = sea_orm::Database::connect(db_url).await.map_err(|err| {
+            error!(error = %err, "Failed to connect to the database");
+            err
+        })?;
         info!("Database connection established");
 
         let db = Arc::new(db);
@@ -49,11 +43,11 @@ impl RepositoriesImpl {
         let record_repo = record::RecordRepositoryImpl::new(db.clone());
         let music_repo = music::MusicRepositoryImpl::new(db.clone());
 
-        Self {
+        Ok(Self {
             user: user_repo,
             record: record_repo,
             music: music_repo,
-        }
+        })
     }
 }
 

--- a/crates/presentation/src/main.rs
+++ b/crates/presentation/src/main.rs
@@ -5,12 +5,12 @@ use tracing::info;
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     load_env();
     init_tracing();
 
     let postgres_url = env::postgres_url();
-    let repositories = infrastructure::RepositoriesImpl::new_default(&postgres_url).await;
+    let repositories = infrastructure::RepositoriesImpl::new_default(&postgres_url).await?;
 
     let config = Config::default();
     let state = State::new(config, repositories);
@@ -20,9 +20,10 @@ async fn main() {
     let app = create_app(state, Some(authenticator));
 
     let addr = format!("{}:{}", env::host(), env::app_port());
-    let listener = TcpListener::bind(&addr).await.unwrap();
+    let listener = TcpListener::bind(&addr).await?;
     info!(%addr, "Starting HTTP server");
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await?;
+    Ok(())
 }
 
 /// Loads environment variables from the `.env` file if present. Implicitly depends on environment


### PR DESCRIPTION
## 概要
- SeaORM の DB 接続失敗を panic せず Result として返す
- HTTP サーバー起動失敗も main からエラー伝播する
- 起動処理の暗黙の panic 契約を doc コメントから削除

## 確認
- cargo fmt --all
- cargo test --workspace --all-targets
- git diff --check