### PR TITLE
APIのエラーレスポンスを統一

### DIFF
--- a/crates/presentation/src/auth.rs
+++ b/crates/presentation/src/auth.rs
@@ -7,6 +7,8 @@ use serde::Deserialize;
 use thiserror::Error;
 use tokio::sync::RwLock;
 
+use crate::error::AppError;
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum PrincipalKind {
     Admin,
@@ -147,18 +149,25 @@ pub async fn middleware(
     axum::extract::State(authenticator): axum::extract::State<Authenticator>,
     mut request: Request,
     next: Next,
-) -> Result<Response, StatusCode> {
+) -> Result<Response, AppError> {
     let token = request
         .headers()
         .get(axum::http::header::AUTHORIZATION)
         .and_then(|value| value.to_str().ok())
         .and_then(|value| value.strip_prefix("Bearer "))
-        .ok_or(StatusCode::UNAUTHORIZED)?;
+        .ok_or_else(|| {
+            AppError::new(
+                StatusCode::UNAUTHORIZED,
+                "Authentication required".to_owned(),
+            )
+        })?;
 
-    let principal = authenticator
-        .authenticate(token)
-        .await
-        .map_err(|_| StatusCode::UNAUTHORIZED)?;
+    let principal = authenticator.authenticate(token).await.map_err(|_| {
+        AppError::new(
+            StatusCode::UNAUTHORIZED,
+            "Invalid authentication token".to_owned(),
+        )
+    })?;
     request.extensions_mut().insert(principal);
     Ok(next.run(request).await)
 }
@@ -167,11 +176,14 @@ pub async fn authorize(
     axum::extract::State(policy): axum::extract::State<AuthorizationPolicy>,
     request: Request,
     next: Next,
-) -> Result<Response, StatusCode> {
+) -> Result<Response, AppError> {
     match request.extensions().get::<Principal>() {
         Some(principal) if policy.allows(principal) => Ok(next.run(request).await),
-        Some(_) => Err(StatusCode::FORBIDDEN),
-        None => Err(StatusCode::UNAUTHORIZED),
+        Some(_) => Err(AppError::new(StatusCode::FORBIDDEN, "Forbidden".to_owned())),
+        None => Err(AppError::new(
+            StatusCode::UNAUTHORIZED,
+            "Authentication required".to_owned(),
+        )),
     }
 }
 

--- a/crates/presentation/src/error/mod.rs
+++ b/crates/presentation/src/error/mod.rs
@@ -6,6 +6,15 @@ pub struct AppError {
 }
 
 impl AppError {
+    pub fn not_found() -> Self {
+        Self::new(
+            axum::http::StatusCode::NOT_FOUND,
+            "Resource not found".to_owned(),
+        )
+    }
+}
+
+impl AppError {
     pub fn new(status_code: axum::http::StatusCode, message: String) -> Self {
         Self {
             status_code,

--- a/crates/presentation/src/error/mod.rs
+++ b/crates/presentation/src/error/mod.rs
@@ -6,20 +6,18 @@ pub struct AppError {
 }
 
 impl AppError {
-    pub fn not_found() -> Self {
-        Self::new(
-            axum::http::StatusCode::NOT_FOUND,
-            "Resource not found".to_owned(),
-        )
-    }
-}
-
-impl AppError {
     pub fn new(status_code: axum::http::StatusCode, message: String) -> Self {
         Self {
             status_code,
             message,
         }
+    }
+
+    pub fn not_found() -> Self {
+        Self::new(
+            axum::http::StatusCode::NOT_FOUND,
+            "Resource not found".to_owned(),
+        )
     }
 }
 

--- a/crates/presentation/src/route/mod.rs
+++ b/crates/presentation/src/route/mod.rs
@@ -73,19 +73,28 @@ pub fn create_app(state: State, authenticator: Option<Authenticator>) -> Router 
     Router::new()
         .merge(private_routes)
         .merge(public_routes)
+        .fallback(crate::route::not_found)
         .layer(TraceLayer::new_for_http())
         .layer(cors)
         .with_state(state)
 }
 
+async fn not_found() -> crate::error::AppError {
+    crate::error::AppError::not_found()
+}
+
 #[cfg(test)]
 mod tests {
-    use axum::{body::Body, http::Request};
+    use axum::{
+        body::{self, Body},
+        http::Request,
+    };
     use domain::repository::{
         MockRepositories, music::MockMusicRepository, record::MockRecordRepository,
         user::MockUserRepository,
     };
     use reqwest::Client;
+    use serde_json::Value;
     use tower::ServiceExt;
 
     use super::*;
@@ -123,5 +132,41 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), axum::http::StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn unknown_route_returns_json_not_found_body() {
+        let response = build_authenticated_router()
+            .oneshot(Request::get("/unknown").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), axum::http::StatusCode::NOT_FOUND);
+        let bytes = body::to_bytes(response.into_body(), 1024).await.unwrap();
+        let body: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["error"], "Resource not found");
+    }
+
+    #[tokio::test]
+    async fn unsupported_method_returns_method_not_allowed() {
+        let repositories = MockRepositories {
+            user: MockUserRepository::new(),
+            record: MockRecordRepository::new(),
+            music: MockMusicRepository::new(),
+        };
+        let state = State::new(crate::config::Config::default(), repositories);
+        let response = create_app(state, None)
+            .oneshot(
+                Request::get("/users/00000000-0000-0000-0000-000000000000")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.status(),
+            axum::http::StatusCode::METHOD_NOT_ALLOWED
+        );
     }
 }


### PR DESCRIPTION
## 概要
- 未定義 route の 404 を JSON body 付きに統一
- 認証失敗・認可失敗も JSON body を返す
- 既存 route の未対応 HTTP method が 405 になることを回帰テストで固定

## 確認
- cargo fmt --all
- cargo test -p presentation --lib route::tests