### PR TITLE
Dockerビルドにキャッシュを追加

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,4 +1,6 @@
-FROM rust:1.90 as builder
+# syntax=docker/dockerfile:1
+
+FROM rust:1.90-slim-bookworm AS builder
 WORKDIR /workspace
 
 RUN apt-get update \
@@ -7,7 +9,10 @@ RUN apt-get update \
 
 COPY . .
 
-RUN cargo build --release --bin presentation --bin migration
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/workspace/target,sharing=locked \
+    cargo build --release --bin presentation --bin migration
 RUN strip target/release/presentation target/release/migration || true
 
 FROM debian:bookworm-slim AS runtime


### PR DESCRIPTION
## 概要
- Rust builder を slim-bookworm に固定
- BuildKit の cargo registry / git / target cache mount を追加
- Dockerfile syntax を明示

## 変更理由
依存クレートとビルド成果物を BuildKit のキャッシュへ保持し、ソースコードのみを変更した場合の本番イメージ再ビルドを高速化する。

## 確認
- 本番イメージの runtime stage は変更なし
- 既存のビルド対象（presentation / migration）を維持