### PR TITLE
管理者向けDB同期 API を追加

### DIFF
--- a/crates/domain/src/repository/user.rs
+++ b/crates/domain/src/repository/user.rs
@@ -37,6 +37,9 @@ pub trait UserRepository: Send + Sync {
         user_id: &str,
     ) -> impl Future<Output = Result<Option<User>, UserRepositoryError>> + Send;
 
+    /// Returns all user aggregates in a stable identifier order for administrative maintenance.
+    fn find_all(&self) -> impl Future<Output = Result<Vec<User>, UserRepositoryError>> + Send;
+
     fn save(&self, user: User) -> impl Future<Output = Result<User, UserRepositoryError>> + Send;
 
     /// Returns the total number of persisted user aggregates.

--- a/crates/infrastructure/src/user/mod.rs
+++ b/crates/infrastructure/src/user/mod.rs
@@ -9,9 +9,10 @@ use domain::{
     repository::user::{UserRepository, UserRepositoryError},
 };
 use read::{
-    count_all as query_count_users, find_by_card as query_by_card, find_by_id as query_by_id,
-    find_play_option as query_play_option, public_users_by_rating as query_public_by_rating,
-    public_users_by_xp as query_public_by_xp, sum_credits as query_sum_credits,
+    count_all as query_count_users, find_all as query_all_users, find_by_card as query_by_card,
+    find_by_id as query_by_id, find_play_option as query_play_option,
+    public_users_by_rating as query_public_by_rating, public_users_by_xp as query_public_by_xp,
+    sum_credits as query_sum_credits,
 };
 use sea_orm::DbConn;
 use tracing::{debug, info, instrument};
@@ -59,6 +60,11 @@ impl UserRepository for UserRepositoryImpl {
     #[instrument(skip(self), fields(user_id = %user_id))]
     async fn find_by_id(&self, user_id: &str) -> Result<Option<User>, UserRepositoryError> {
         query_by_id(self.db.as_ref(), user_id).await
+    }
+
+    #[instrument(skip(self))]
+    async fn find_all(&self) -> Result<Vec<User>, UserRepositoryError> {
+        query_all_users(self.db.as_ref()).await
     }
 
     #[instrument(skip(self, user), fields(user_id = %user.id()))]

--- a/crates/infrastructure/src/user/read.rs
+++ b/crates/infrastructure/src/user/read.rs
@@ -49,6 +49,19 @@ pub async fn find_by_id(db: &DbConn, user_id: &str) -> Result<Option<User>, User
     model.map(User::try_from).transpose()
 }
 
+pub async fn find_all(db: &DbConn) -> Result<Vec<User>, UserRepositoryError> {
+    let models = entities::users::Entity::find()
+        .order_by_asc(entities::users::Column::Id)
+        .all(db)
+        .await
+        .map_err(|err| {
+            error!(error = %err, "Failed to query all users");
+            UserRepositoryError::InternalError(AnyError::from(err))
+        })?;
+
+    models.into_iter().map(User::try_from).collect()
+}
+
 pub async fn find_play_option(
     db: &DbConn,
     user_id: &str,

--- a/crates/presentation/src/auth.rs
+++ b/crates/presentation/src/auth.rs
@@ -267,4 +267,14 @@ mod tests {
 
         assert!(policy.allows(&principal));
     }
+
+    #[test]
+    fn admin_policy_rejects_device_principal() {
+        let policy = super::AuthorizationPolicy::only(PrincipalKind::Admin);
+        let principal = Principal::Device {
+            client_id: "device-client".into(),
+        };
+
+        assert!(!policy.allows(&principal));
+    }
 }

--- a/crates/presentation/src/route/admin.rs
+++ b/crates/presentation/src/route/admin.rs
@@ -6,14 +6,21 @@ use crate::error::AppError;
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct RecalculateRatingsResponse {
+pub struct DbSynchronizationResponse {
     pub updated_users: u64,
+    pub updated_ratings: u64,
 }
 
-pub async fn handle_recalculate_ratings(
+pub async fn handle_db_synchronization(
     State(state): State<crate::state::State>,
-) -> Result<Json<RecalculateRatingsResponse>, AppError> {
-    let updated_users = state.usecases.user.recalculate_ratings().await?;
-    info!(updated_users, "Admin rating recalculation completed");
-    Ok(Json(RecalculateRatingsResponse { updated_users }))
+) -> Result<Json<DbSynchronizationResponse>, AppError> {
+    let result = state.usecases.user.synchronize_db().await?;
+    info!(
+        updated_users = result.updated_users,
+        "Admin database synchronization completed"
+    );
+    Ok(Json(DbSynchronizationResponse {
+        updated_users: result.updated_users,
+        updated_ratings: result.updated_ratings,
+    }))
 }

--- a/crates/presentation/src/route/admin.rs
+++ b/crates/presentation/src/route/admin.rs
@@ -1,0 +1,19 @@
+use axum::{Json, extract::State};
+use serde::Serialize;
+use tracing::info;
+
+use crate::error::AppError;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecalculateRatingsResponse {
+    pub updated_users: u64,
+}
+
+pub async fn handle_recalculate_ratings(
+    State(state): State<crate::state::State>,
+) -> Result<Json<RecalculateRatingsResponse>, AppError> {
+    let updated_users = state.usecases.user.recalculate_ratings().await?;
+    info!(updated_users, "Admin rating recalculation completed");
+    Ok(Json(RecalculateRatingsResponse { updated_users }))
+}

--- a/crates/presentation/src/route/mod.rs
+++ b/crates/presentation/src/route/mod.rs
@@ -43,10 +43,8 @@ pub fn create_app(state: State, authenticator: Option<Authenticator>) -> Router 
         .route("/rating", get(ranking::handle_get_rating_ranking))
         .route("/xp", get(ranking::handle_get_xp_ranking));
     let health = Router::new().route("/", get(|| async { "OK" }));
-    let admin_routes = Router::new().route(
-        "/users/rating/recalculate",
-        post(admin::handle_recalculate_ratings),
-    );
+    let admin_routes =
+        Router::new().route("/db/synchronize", post(admin::handle_db_synchronization));
 
     let private_routes = Router::new()
         .nest("/users", users)
@@ -139,7 +137,7 @@ mod tests {
     async fn admin_route_requires_authentication() {
         let response = build_authenticated_router()
             .oneshot(
-                Request::post("/admin/users/rating/recalculate")
+                Request::post("/admin/db/synchronize")
                     .body(Body::empty())
                     .unwrap(),
             )

--- a/crates/presentation/src/route/mod.rs
+++ b/crates/presentation/src/route/mod.rs
@@ -12,6 +12,7 @@ use crate::{
     state::State,
 };
 
+pub mod admin;
 pub mod ranking;
 pub mod statistics;
 pub mod sync;
@@ -42,11 +43,15 @@ pub fn create_app(state: State, authenticator: Option<Authenticator>) -> Router 
         .route("/rating", get(ranking::handle_get_rating_ranking))
         .route("/xp", get(ranking::handle_get_xp_ranking));
     let health = Router::new().route("/", get(|| async { "OK" }));
+    let admin_routes = Router::new().route(
+        "/users/rating/recalculate",
+        post(admin::handle_recalculate_ratings),
+    );
 
     let private_routes = Router::new()
         .nest("/users", users)
         .nest("/sync", sync_route);
-    let private_routes = if let Some(authenticator) = authenticator {
+    let private_routes = if let Some(authenticator) = authenticator.clone() {
         private_routes
             .layer(middleware::from_fn_with_state(
                 AuthorizationPolicy::only(PrincipalKind::Device),
@@ -58,6 +63,20 @@ pub fn create_app(state: State, authenticator: Option<Authenticator>) -> Router 
             ))
     } else {
         private_routes
+    };
+
+    let admin_routes = if let Some(authenticator) = authenticator {
+        admin_routes
+            .layer(middleware::from_fn_with_state(
+                AuthorizationPolicy::only(PrincipalKind::Admin),
+                crate::auth::authorize,
+            ))
+            .layer(middleware::from_fn_with_state(
+                authenticator,
+                crate::auth::middleware,
+            ))
+    } else {
+        admin_routes
     };
 
     let public_routes = Router::new()
@@ -72,6 +91,7 @@ pub fn create_app(state: State, authenticator: Option<Authenticator>) -> Router 
 
     Router::new()
         .merge(private_routes)
+        .nest("/admin", admin_routes)
         .merge(public_routes)
         .layer(TraceLayer::new_for_http())
         .layer(cors)
@@ -109,6 +129,20 @@ mod tests {
     async fn private_route_requires_authentication() {
         let response = build_authenticated_router()
             .oneshot(Request::get("/sync").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), axum::http::StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn admin_route_requires_authentication() {
+        let response = build_authenticated_router()
+            .oneshot(
+                Request::post("/admin/users/rating/recalculate")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
             .await
             .unwrap();
 

--- a/crates/usecase/src/user/mod.rs
+++ b/crates/usecase/src/user/mod.rs
@@ -5,6 +5,7 @@ use thiserror::Error;
 
 pub mod credits;
 pub mod options;
+pub mod recalculate_ratings;
 pub mod records;
 pub mod register;
 pub mod search;

--- a/crates/usecase/src/user/mod.rs
+++ b/crates/usecase/src/user/mod.rs
@@ -5,10 +5,10 @@ use thiserror::Error;
 
 pub mod credits;
 pub mod options;
-pub mod recalculate_ratings;
 pub mod records;
 pub mod register;
 pub mod search;
+pub mod synchronize;
 pub mod update;
 
 #[derive(Debug, Error)]
@@ -27,6 +27,12 @@ pub enum UserUsecaseError {
 
 pub struct UserUsecase<R: Repositories> {
     repositories: Arc<R>,
+}
+
+#[derive(Debug, Default, Eq, PartialEq)]
+pub struct DbSynchronizationResult {
+    pub updated_users: u64,
+    pub updated_ratings: u64,
 }
 
 impl<R: Repositories> UserUsecase<R> {

--- a/crates/usecase/src/user/recalculate_ratings.rs
+++ b/crates/usecase/src/user/recalculate_ratings.rs
@@ -1,0 +1,37 @@
+use domain::{
+    repository::{Repositories, record::RecordRepository, user::UserRepository},
+    service::rating,
+};
+use tracing::{debug, info, instrument};
+
+use super::{UserUsecase, UserUsecaseError};
+
+impl<R: Repositories> UserUsecase<R> {
+    /// Recalculates persisted ratings for every user from the current rating policy.
+    #[instrument(skip(self))]
+    pub async fn recalculate_ratings(&self) -> Result<u64, UserUsecaseError> {
+        let users = self.repositories.user().find_all().await?;
+        let mut updated = 0;
+
+        for mut user in users {
+            let user_id = user.id().to_owned();
+            let records = self
+                .repositories
+                .record()
+                .find_with_metadata_by_user_id(&user_id)
+                .await
+                .map_err(UserUsecaseError::RecordRepositoryError)?;
+            let new_rating = rating::calculate_user_rating(&records);
+
+            if user.rating().value() != new_rating.value() {
+                debug!(%user_id, "Updating rating during recalculation");
+                user.update_rating(new_rating);
+                self.repositories.user().save(user).await?;
+                updated += 1;
+            }
+        }
+
+        info!(updated, "User ratings recalculated");
+        Ok(updated)
+    }
+}

--- a/crates/usecase/src/user/synchronize.rs
+++ b/crates/usecase/src/user/synchronize.rs
@@ -7,11 +7,11 @@ use tracing::{debug, info, instrument};
 use super::{UserUsecase, UserUsecaseError};
 
 impl<R: Repositories> UserUsecase<R> {
-    /// Recalculates persisted ratings for every user from the current rating policy.
+    /// Synchronizes persisted user values with the current domain rules.
     #[instrument(skip(self))]
-    pub async fn recalculate_ratings(&self) -> Result<u64, UserUsecaseError> {
+    pub async fn synchronize_db(&self) -> Result<super::DbSynchronizationResult, UserUsecaseError> {
         let users = self.repositories.user().find_all().await?;
-        let mut updated = 0;
+        let mut result = super::DbSynchronizationResult::default();
 
         for mut user in users {
             let user_id = user.id().to_owned();
@@ -24,14 +24,18 @@ impl<R: Repositories> UserUsecase<R> {
             let new_rating = rating::calculate_user_rating(&records);
 
             if user.rating().value() != new_rating.value() {
-                debug!(%user_id, "Updating rating during recalculation");
+                debug!(%user_id, "Updating rating during database synchronization");
                 user.update_rating(new_rating);
                 self.repositories.user().save(user).await?;
-                updated += 1;
+                result.updated_users += 1;
+                result.updated_ratings += 1;
             }
         }
 
-        info!(updated, "User ratings recalculated");
-        Ok(updated)
+        info!(
+            updated_users = result.updated_users,
+            "Database synchronization completed"
+        );
+        Ok(result)
     }
 }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -112,12 +112,12 @@ paths:
           description: Not found - User not found
         "500":
           description: Internal server error
-  /admin/users/rating/recalculate:
+  /admin/db/synchronize:
     post:
       tags:
         - admin
-      summary: ユーザーのレートを再計算
-      description: 現在のレート計算仕様に基づいて、全ユーザーの保存済みレートを再計算する。値が変わるユーザーのみ更新する。
+      summary: DBの派生値を同期
+      description: 現在のドメインルールに基づいて、DBに保存された派生値を同期する。値が変わるユーザーのみ更新する。
       security:
         - userAuth: []
       responses:
@@ -131,8 +131,12 @@ paths:
                   updatedUsers:
                     type: integer
                     format: int64
+                  updatedRatings:
+                    type: integer
+                    format: int64
                 required:
                   - updatedUsers
+                  - updatedRatings
         "401":
           description: Unauthorized - Invalid user access token
         "403":

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -112,6 +112,33 @@ paths:
           description: Not found - User not found
         "500":
           description: Internal server error
+  /admin/users/rating/recalculate:
+    post:
+      tags:
+        - admin
+      summary: ユーザーのレートを再計算
+      description: 現在のレート計算仕様に基づいて、全ユーザーの保存済みレートを再計算する。値が変わるユーザーのみ更新する。
+      security:
+        - userAuth: []
+      responses:
+        "200":
+          description: Recalculation completed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  updatedUsers:
+                    type: integer
+                    format: int64
+                required:
+                  - updatedUsers
+        "401":
+          description: Unauthorized - Invalid user access token
+        "403":
+          description: Forbidden - The authenticated user is not an administrator
+        "500":
+          description: Internal server error
   /users/{userId}/credits/increment:
     post:
       tags:


### PR DESCRIPTION
## 概要
- `POST /admin/db/synchronize` を追加
- `userAuth` の管理者 principal のみアクセス可能に設定
- DBに保存されたユーザーの派生値を現在のドメインルールへ同期
- 現時点では rating を同期し、将来の派生値を同じ処理へ追加しやすい構成に整理
- 値が変わるユーザーだけ保存する冪等な処理を実装
- 更新ユーザー数と更新rating数を返却
- OpenAPI と認証必須の回帰テストを追加

## 再計算対象
- 現時点では仕様変更が発生した `rating` のみ
- `xp` は過去の各プレイのスコア履歴を保持していないため、正確な再計算は不可
- ランキング・統計の集計値は保存値ではなく都度集計のため対象外

## マージ順
このPRはレート計算変更の [#42](https://github.com/xlair-dev/server/pull/42) を前提とする。#42 を先にマージしてから本PRをマージする。

## 確認
- cargo fmt --all
- cargo test --workspace --all-targets
- git diff --check