### PR TITLE
Compose起動時のマイグレーション実行を停止

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ API server for XLAIR
 ```sh
 docker compose up -d
 docker compose --profile migration run --rm migrator up
+cargo run -p presentation
 ```
 
 マイグレーションを追加した場合も、同じコマンドで未適用分だけが適用されます。開発用DBを作り直す場合に限り、次を実行してください。

--- a/README.md
+++ b/README.md
@@ -2,6 +2,21 @@
 
 API server for XLAIR
 
+## ローカル開発
+
+通常の起動ではDBコンテナだけを起動します。マイグレーションは必要なときに明示的に実行してください。
+
+```sh
+docker compose up -d
+docker compose --profile migration run --rm migrator up
+```
+
+マイグレーションを追加した場合も、同じコマンドで未適用分だけが適用されます。開発用DBを作り直す場合に限り、次を実行してください。
+
+```sh
+docker compose --profile migration run --rm migrator refresh
+```
+
 ## デプロイ手順 (オンプレ)
 
 1. `.env.prod.example` を参考に本番用 `.env` を作成します。
@@ -12,7 +27,7 @@ API server for XLAIR
    ```
 3. スキーマ変更がある場合は、アプリ再起動前に以下でマイグレーションを実行します。
    ```sh
-   docker compose --env-file ./.env -f compose.prod.yml run --rm migrator refresh
+   docker compose --env-file ./.env -f compose.prod.yml --profile migration run --rm migrator up
    ```
 
 ## CI での想定フロー

--- a/compose.yml
+++ b/compose.yml
@@ -25,8 +25,9 @@ services:
     depends_on:
       db:
         condition: service_healthy
-    command: >
-      bash -c "cargo run -p migration -- refresh"
+    profiles:
+      - migration
+    command: cargo run -p migration -- up
     restart: "no"
 
 volumes:

--- a/crates/migration/README.md
+++ b/crates/migration/README.md
@@ -6,9 +6,6 @@
     ```
 - Apply all pending migrations
     ```sh
-    cargo run
-    ```
-    ```sh
     cargo run -- up
     ```
 - Apply first 10 pending migrations
@@ -28,6 +25,7 @@
     cargo run -- fresh
     ```
 - Rollback all applied migrations, then reapply all migrations
+  This command is destructive and should only be used when intentionally rebuilding the database.
     ```sh
     cargo run -- refresh
     ```


### PR DESCRIPTION
## 概要
- 開発用migratorを `migration` profileへ移動
- 通常の `docker compose up` ではmigratorを起動しない構成へ変更
- 通常の適用は `migrate up` を使用し、未適用分だけを適用
- 本番READMEの手順も `up` に変更
- `refresh` は意図的なDB再構築時だけ使うよう説明を追加

## 確認
- `docker compose config -q`
- `docker compose -f compose.prod.yml config -q`
- `docker compose config --services`
- `git diff --check`